### PR TITLE
feat: 스와이프 dismiss 스낵바 및 구독/저장 해제 Undo 피드백 추가

### DIFF
--- a/app/src/main/kotlin/io/jacob/episodive/ui/EpisodiveApp.kt
+++ b/app/src/main/kotlin/io/jacob/episodive/ui/EpisodiveApp.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
@@ -36,6 +35,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.jacob.episodive.DeepLinkEvent
 import io.jacob.episodive.R
 import io.jacob.episodive.core.designsystem.component.EpisodiveBackground
+import io.jacob.episodive.core.designsystem.component.EpisodiveSwipeDismissSnackbarHost
+import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.component.EpisodiveNavigationBar
 import io.jacob.episodive.core.designsystem.component.EpisodiveNavigationBarItem
 import io.jacob.episodive.feature.onboarding.OnboardingRoute
@@ -76,22 +77,26 @@ fun EpisodiveApp(
 ) {
     val state by appState.viewModel.state.collectAsStateWithLifecycle()
 
+    val onShowSnackbar: suspend (String, String?) -> Boolean = remember {
+        { message: String, action: String? ->
+            snackbarHostState.showSnackbar(
+                message = message,
+                actionLabel = action,
+                duration = if (action != null) SnackbarDuration.Long else SnackbarDuration.Short,
+            ) == SnackbarResult.ActionPerformed
+        }
+    }
+
     if (state.isFirstLaunch()) {
         Box(
             modifier = Modifier
                 .fillMaxSize(),
         ) {
             OnboardingRoute(
-                onShowSnackbar = { message, action ->
-                    snackbarHostState.showSnackbar(
-                        message = message,
-                        actionLabel = action,
-                        duration = SnackbarDuration.Short,
-                    ) == SnackbarResult.ActionPerformed
-                },
+                onShowSnackbar = onShowSnackbar,
             )
 
-            SnackbarHost(
+            EpisodiveSwipeDismissSnackbarHost(
                 hostState = snackbarHostState,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -167,9 +172,11 @@ fun EpisodiveApp(
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets
             .exclude(WindowInsets.statusBars),
         snackbarHost = {
-            SnackbarHost(
-                snackbarHostState,
-                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
+            EpisodiveSwipeDismissSnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(bottom = LocalDimensionTheme.current.playerBarHeight),
             )
         },
     ) { paddingValues ->
@@ -180,17 +187,12 @@ fun EpisodiveApp(
             EpisodiveNavHost(
                 navigationState = appState.navigationState,
                 navigator = appState.navigator,
-                onShowSnackbar = { message, action ->
-                    snackbarHostState.showSnackbar(
-                        message = message,
-                        actionLabel = action,
-                        duration = SnackbarDuration.Short,
-                    ) == SnackbarResult.ActionPerformed
-                },
+                onShowSnackbar = onShowSnackbar,
             )
 
             PlayerBar(
-                onPodcastClick = { appState.navigateToPodcast(it) }
+                onPodcastClick = { appState.navigateToPodcast(it) },
+                onShowSnackbar = onShowSnackbar,
             )
         }
     }

--- a/core/database/schemas/io.jacob.episodive.core.database.EpisodiveDatabase/11.json
+++ b/core/database/schemas/io.jacob.episodive.core.database.EpisodiveDatabase/11.json
@@ -1,0 +1,1148 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "35da081b174a3e4642ea87b244063f0a",
+    "entities": [
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `podcastGuid` TEXT NOT NULL, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `originalUrl` TEXT NOT NULL, `link` TEXT NOT NULL, `description` TEXT NOT NULL, `author` TEXT NOT NULL, `ownerName` TEXT NOT NULL, `image` TEXT NOT NULL, `artwork` TEXT NOT NULL, `lastUpdateTime` INTEGER NOT NULL, `lastCrawlTime` INTEGER NOT NULL, `lastParseTime` INTEGER NOT NULL, `lastGoodHttpStatusTime` INTEGER NOT NULL, `lastHttpStatus` INTEGER NOT NULL, `contentType` TEXT NOT NULL, `itunesId` INTEGER, `itunesType` TEXT, `generator` TEXT, `language` TEXT NOT NULL, `explicit` INTEGER, `type` INTEGER NOT NULL, `medium` TEXT, `dead` INTEGER NOT NULL, `chash` TEXT, `episodeCount` INTEGER NOT NULL, `crawlErrors` INTEGER NOT NULL, `parseErrors` INTEGER NOT NULL, `categories` TEXT NOT NULL, `locked` INTEGER NOT NULL, `imageUrlHash` INTEGER, `newestItemPublishTime` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastGuid",
+            "columnName": "podcastGuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUrl",
+            "columnName": "originalUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerName",
+            "columnName": "ownerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artwork",
+            "columnName": "artwork",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCrawlTime",
+            "columnName": "lastCrawlTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastParseTime",
+            "columnName": "lastParseTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastGoodHttpStatusTime",
+            "columnName": "lastGoodHttpStatusTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHttpStatus",
+            "columnName": "lastHttpStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itunesId",
+            "columnName": "itunesId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "itunesType",
+            "columnName": "itunesType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generator",
+            "columnName": "generator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "medium",
+            "columnName": "medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dead",
+            "columnName": "dead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chash",
+            "columnName": "chash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeCount",
+            "columnName": "episodeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "crawlErrors",
+            "columnName": "crawlErrors",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parseErrors",
+            "columnName": "parseErrors",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrlHash",
+            "columnName": "imageUrlHash",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "newestItemPublishTime",
+            "columnName": "newestItemPublishTime",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "podcasts_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `description` TEXT NOT NULL, `author` TEXT NOT NULL, `ownerName` TEXT NOT NULL, content=`podcasts`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerName",
+            "columnName": "ownerName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "podcasts",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_podcasts_fts_BEFORE_UPDATE BEFORE UPDATE ON `podcasts` BEGIN DELETE FROM `podcasts_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_podcasts_fts_BEFORE_DELETE BEFORE DELETE ON `podcasts` BEGIN DELETE FROM `podcasts_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_podcasts_fts_AFTER_UPDATE AFTER UPDATE ON `podcasts` BEGIN INSERT INTO `podcasts_fts`(`docid`, `title`, `description`, `author`, `ownerName`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`description`, NEW.`author`, NEW.`ownerName`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_podcasts_fts_AFTER_INSERT AFTER INSERT ON `podcasts` BEGIN INSERT INTO `podcasts_fts`(`docid`, `title`, `description`, `author`, `ownerName`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`description`, NEW.`author`, NEW.`ownerName`); END"
+        ]
+      },
+      {
+        "tableName": "podcast_group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupKey` TEXT NOT NULL, `id` INTEGER NOT NULL, `order` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`groupKey`, `id`), FOREIGN KEY(`id`) REFERENCES `podcasts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupKey",
+            "columnName": "groupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupKey",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_podcast_group_groupKey",
+            "unique": false,
+            "columnNames": [
+              "groupKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_podcast_group_groupKey` ON `${TABLE_NAME}` (`groupKey`)"
+          },
+          {
+            "name": "index_podcast_group_id",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_podcast_group_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_podcast_group_groupKey_createdAt",
+            "unique": false,
+            "columnNames": [
+              "groupKey",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_podcast_group_groupKey_createdAt` ON `${TABLE_NAME}` (`groupKey`, `createdAt`)"
+          },
+          {
+            "name": "index_podcast_group_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_podcast_group_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "podcasts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "followed_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `followedAt` INTEGER NOT NULL, `isNotificationEnabled` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`id`) REFERENCES `podcasts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNotificationEnabled",
+            "columnName": "isNotificationEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_followed_podcasts_followedAt",
+            "unique": false,
+            "columnNames": [
+              "followedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_followed_podcasts_followedAt` ON `${TABLE_NAME}` (`followedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "podcasts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `link` TEXT NOT NULL, `description` TEXT, `guid` TEXT NOT NULL, `datePublished` INTEGER NOT NULL, `dateCrawled` INTEGER NOT NULL, `enclosureUrl` TEXT NOT NULL, `enclosureType` TEXT NOT NULL, `enclosureLength` INTEGER NOT NULL, `startTime` INTEGER, `endTime` INTEGER, `status` TEXT, `contentLink` TEXT, `duration` INTEGER, `explicit` INTEGER NOT NULL, `episode` INTEGER, `episodeType` TEXT, `season` INTEGER, `image` TEXT NOT NULL, `feedItunesId` INTEGER, `feedImage` TEXT NOT NULL, `feedId` INTEGER NOT NULL, `feedUrl` TEXT, `feedAuthor` TEXT, `feedTitle` TEXT, `feedLanguage` TEXT NOT NULL, `categories` TEXT NOT NULL, `chaptersUrl` TEXT, `transcriptUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "guid",
+            "columnName": "guid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCrawled",
+            "columnName": "dateCrawled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enclosureUrl",
+            "columnName": "enclosureUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enclosureType",
+            "columnName": "enclosureType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enclosureLength",
+            "columnName": "enclosureLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentLink",
+            "columnName": "contentLink",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode",
+            "columnName": "episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeType",
+            "columnName": "episodeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedItunesId",
+            "columnName": "feedItunesId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "feedImage",
+            "columnName": "feedImage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedUrl",
+            "columnName": "feedUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "feedAuthor",
+            "columnName": "feedAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "feedTitle",
+            "columnName": "feedTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "feedLanguage",
+            "columnName": "feedLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersUrl",
+            "columnName": "chaptersUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transcriptUrl",
+            "columnName": "transcriptUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `description` TEXT NOT NULL, `feedAuthor` TEXT, `feedTitle` TEXT, content=`episodes`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedAuthor",
+            "columnName": "feedAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "feedTitle",
+            "columnName": "feedTitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "episodes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_UPDATE BEFORE UPDATE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_DELETE BEFORE DELETE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_UPDATE AFTER UPDATE ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `title`, `description`, `feedAuthor`, `feedTitle`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`description`, NEW.`feedAuthor`, NEW.`feedTitle`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_INSERT AFTER INSERT ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `title`, `description`, `feedAuthor`, `feedTitle`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`description`, NEW.`feedAuthor`, NEW.`feedTitle`); END"
+        ]
+      },
+      {
+        "tableName": "episode_group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupKey` TEXT NOT NULL, `id` INTEGER NOT NULL, `order` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`groupKey`, `id`), FOREIGN KEY(`id`) REFERENCES `episodes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupKey",
+            "columnName": "groupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupKey",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episode_group_groupKey",
+            "unique": false,
+            "columnNames": [
+              "groupKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episode_group_groupKey` ON `${TABLE_NAME}` (`groupKey`)"
+          },
+          {
+            "name": "index_episode_group_id",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episode_group_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_episode_group_groupKey_createdAt",
+            "unique": false,
+            "columnNames": [
+              "groupKey",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episode_group_groupKey_createdAt` ON `${TABLE_NAME}` (`groupKey`, `createdAt`)"
+          },
+          {
+            "name": "index_episode_group_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episode_group_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "liked_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `likedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`id`) REFERENCES `episodes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedAt",
+            "columnName": "likedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_liked_episodes_likedAt",
+            "unique": false,
+            "columnNames": [
+              "likedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_liked_episodes_likedAt` ON `${TABLE_NAME}` (`likedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "played_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `playedAt` INTEGER NOT NULL, `position` INTEGER NOT NULL, `isCompleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`id`) REFERENCES `episodes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "playedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_played_episodes_playedAt",
+            "unique": false,
+            "columnNames": [
+              "playedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_played_episodes_playedAt` ON `${TABLE_NAME}` (`playedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "feeds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `newestItemPublishTime` INTEGER NOT NULL, `description` TEXT, `image` TEXT, `itunesId` INTEGER, `language` TEXT NOT NULL, `categories` TEXT NOT NULL, `groupKey` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newestItemPublishTime",
+            "columnName": "newestItemPublishTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "itunesId",
+            "columnName": "itunesId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupKey",
+            "columnName": "groupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "soundbites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`enclosureUrl` TEXT NOT NULL, `title` TEXT NOT NULL, `startTime` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `episodeId` INTEGER NOT NULL, `episodeTitle` TEXT NOT NULL, `feedTitle` TEXT NOT NULL, `feedUrl` TEXT NOT NULL, `feedId` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`episodeId`))",
+        "fields": [
+          {
+            "fieldPath": "enclosureUrl",
+            "columnName": "enclosureUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeId",
+            "columnName": "episodeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeTitle",
+            "columnName": "episodeTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedTitle",
+            "columnName": "feedTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedUrl",
+            "columnName": "feedUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeId"
+          ]
+        }
+      },
+      {
+        "tableName": "recent_searches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `query` TEXT, `contentId` INTEGER, `title` TEXT, `imageUrl` TEXT, `subtitle` TEXT, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "contentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recent_searches_type_contentId",
+            "unique": true,
+            "columnNames": [
+              "type",
+              "contentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_recent_searches_type_contentId` ON `${TABLE_NAME}` (`type`, `contentId`)"
+          },
+          {
+            "name": "index_recent_searches_type_query",
+            "unique": true,
+            "columnNames": [
+              "type",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_recent_searches_type_query` ON `${TABLE_NAME}` (`type`, `query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "saved_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `podcastId` INTEGER NOT NULL, `savedAt` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `totalSize` INTEGER NOT NULL, `downloadedSize` INTEGER NOT NULL, `downloadStatus` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`id`) REFERENCES `episodes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcastId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSize",
+            "columnName": "totalSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedSize",
+            "columnName": "downloadedSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "downloadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_episodes_savedAt",
+            "unique": false,
+            "columnNames": [
+              "savedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_episodes_savedAt` ON `${TABLE_NAME}` (`savedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "podcast_with_extras",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n            podcasts.*,\n            followed_podcasts.followedAt AS followedAt,\n            followed_podcasts.isNotificationEnabled AS isNotificationEnabled\n        FROM podcasts\n        LEFT JOIN followed_podcasts ON podcasts.id = followed_podcasts.id"
+      },
+      {
+        "viewName": "episode_with_extras",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n            episodes.*,\n            liked_episodes.likedAt AS likedAt,\n            played_episodes.playedAt AS playedAt,\n            played_episodes.position AS position,\n            played_episodes.isCompleted AS isCompleted,\n            soundbites.startTime AS clipStartTime,\n            soundbites.duration AS clipDuration,\n            saved_episodes.savedAt AS savedAt,\n            saved_episodes.filePath AS filePath,\n            saved_episodes.downloadStatus AS downloadStatus,\n            saved_episodes.downloadedSize AS downloadedSize,\n            saved_episodes.totalSize AS totalSize\n        FROM episodes\n        LEFT JOIN liked_episodes ON episodes.id = liked_episodes.id\n        LEFT JOIN played_episodes ON episodes.id = played_episodes.id\n        LEFT JOIN soundbites ON episodes.id = soundbites.episodeId\n        LEFT JOIN saved_episodes ON episodes.id = saved_episodes.id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '35da081b174a3e4642ea87b244063f0a')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/EpisodiveDatabase.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/EpisodiveDatabase.kt
@@ -57,7 +57,7 @@ import io.jacob.episodive.core.database.util.RecentSearchTypeConverter
         PodcastWithExtrasView::class,
         EpisodeWithExtrasView::class,
     ],
-    version = 10,
+    version = 11,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3, spec = AutoMigration2to3::class),

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/di/DatabaseModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import io.jacob.episodive.core.database.BuildConfig
 import io.jacob.episodive.core.database.EpisodiveDatabase
 import io.jacob.episodive.core.database.migration.Migration8to9
+import io.jacob.episodive.core.database.migration.Migration10to11
 import io.jacob.episodive.core.database.migration.Migration9to10
 import javax.inject.Singleton
 
@@ -26,7 +27,7 @@ object DatabaseModule {
             EpisodiveDatabase::class.java,
             "episodive-database",
         ).apply {
-            addMigrations(Migration8to9, Migration9to10)
+            addMigrations(Migration8to9, Migration9to10, Migration10to11)
             if (BuildConfig.DEBUG) {
                 fallbackToDestructiveMigrationFrom(true, 3)
             }

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/mapper/DatabaseMapper.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/mapper/DatabaseMapper.kt
@@ -150,6 +150,11 @@ fun EpisodeWithExtrasView.toEpisode(): Episode =
         savedAt = savedAt,
         filePath = filePath,
         downloadStatus = downloadStatus,
+        downloadProgress = if (totalSize != null && totalSize > 0) {
+            (downloadedSize ?: 0L).toFloat() / totalSize
+        } else {
+            0f
+        },
     )
 
 fun List<EpisodeWithExtrasView>.toEpisodes(): List<Episode> =

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/migration/Migration10to11.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/migration/Migration10to11.kt
@@ -1,0 +1,31 @@
+package io.jacob.episodive.core.database.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val Migration10to11 = object : Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DROP VIEW IF EXISTS episode_with_extras")
+
+        db.execSQL(
+            "CREATE VIEW `episode_with_extras` AS SELECT\n" +
+                "            episodes.*,\n" +
+                "            liked_episodes.likedAt AS likedAt,\n" +
+                "            played_episodes.playedAt AS playedAt,\n" +
+                "            played_episodes.position AS position,\n" +
+                "            played_episodes.isCompleted AS isCompleted,\n" +
+                "            soundbites.startTime AS clipStartTime,\n" +
+                "            soundbites.duration AS clipDuration,\n" +
+                "            saved_episodes.savedAt AS savedAt,\n" +
+                "            saved_episodes.filePath AS filePath,\n" +
+                "            saved_episodes.downloadStatus AS downloadStatus,\n" +
+                "            saved_episodes.downloadedSize AS downloadedSize,\n" +
+                "            saved_episodes.totalSize AS totalSize\n" +
+                "        FROM episodes\n" +
+                "        LEFT JOIN liked_episodes ON episodes.id = liked_episodes.id\n" +
+                "        LEFT JOIN played_episodes ON episodes.id = played_episodes.id\n" +
+                "        LEFT JOIN soundbites ON episodes.id = soundbites.episodeId\n" +
+                "        LEFT JOIN saved_episodes ON episodes.id = saved_episodes.id"
+        )
+    }
+}

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/model/EpisodeWithExtrasView.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/model/EpisodeWithExtrasView.kt
@@ -19,7 +19,9 @@ import kotlin.time.Instant
             soundbites.duration AS clipDuration,
             saved_episodes.savedAt AS savedAt,
             saved_episodes.filePath AS filePath,
-            saved_episodes.downloadStatus AS downloadStatus
+            saved_episodes.downloadStatus AS downloadStatus,
+            saved_episodes.downloadedSize AS downloadedSize,
+            saved_episodes.totalSize AS totalSize
         FROM episodes
         LEFT JOIN liked_episodes ON episodes.id = liked_episodes.id
         LEFT JOIN played_episodes ON episodes.id = played_episodes.id
@@ -38,4 +40,6 @@ data class EpisodeWithExtrasView(
     val savedAt: Instant? = null,
     val filePath: String? = null,
     val downloadStatus: DownloadStatus? = null,
+    val downloadedSize: Long? = null,
+    val totalSize: Long? = null,
 )

--- a/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/component/Snackbar.kt
+++ b/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/component/Snackbar.kt
@@ -1,0 +1,73 @@
+package io.jacob.episodive.core.designsystem.component
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import io.jacob.episodive.core.designsystem.theme.EpisodiveTheme
+import io.jacob.episodive.core.designsystem.tooling.ThemePreviews
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+@Composable
+fun EpisodiveSwipeDismissSnackbarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+) {
+    SnackbarHost(
+        hostState = hostState,
+        modifier = modifier,
+    ) { snackbarData ->
+        val offsetY = remember { Animatable(0f) }
+        val scope = rememberCoroutineScope()
+
+        Snackbar(
+            snackbarData = snackbarData,
+            modifier = Modifier
+                .offset { IntOffset(0, offsetY.value.roundToInt()) }
+                .draggable(
+                    orientation = Orientation.Vertical,
+                    state = rememberDraggableState { delta ->
+                        scope.launch { offsetY.snapTo(offsetY.value + delta) }
+                    },
+                    onDragStopped = {
+                        if (abs(offsetY.value) > DISMISS_THRESHOLD) {
+                            snackbarData.dismiss()
+                        } else {
+                            scope.launch { offsetY.animateTo(0f) }
+                        }
+                    },
+                ),
+        )
+    }
+}
+
+private const val DISMISS_THRESHOLD = 80f
+
+@ThemePreviews
+@Composable
+private fun EpisodiveSwipeDismissSnackbarPreview() {
+    EpisodiveTheme {
+        val snackbarHostState = remember { SnackbarHostState() }
+        LaunchedEffect(Unit) {
+            snackbarHostState.showSnackbar(
+                message = "팟캐스트를 구독했습니다",
+                actionLabel = "실행 취소",
+                duration = SnackbarDuration.Indefinite,
+            )
+        }
+        EpisodiveSwipeDismissSnackbarHost(hostState = snackbarHostState)
+    }
+}

--- a/core/model/src/main/kotlin/io/jacob/episodive/core/model/Episode.kt
+++ b/core/model/src/main/kotlin/io/jacob/episodive/core/model/Episode.kt
@@ -44,6 +44,7 @@ data class Episode(
     val savedAt: Instant? = null,
     val filePath: String? = null,
     val downloadStatus: DownloadStatus? = null,
+    val downloadProgress: Float = 0f,
 ) {
     val isLive: Boolean
         get() = enclosureLength == 0L ||
@@ -55,6 +56,9 @@ data class Episode(
     val isLiked: Boolean = likedAt != null
 
     val isSaved: Boolean = savedAt != null
+
+    val isDownloading: Boolean
+        get() = downloadStatus == DownloadStatus.PENDING || downloadStatus == DownloadStatus.DOWNLOADING
 
     val isDownloaded: Boolean = downloadStatus == DownloadStatus.COMPLETED
 

--- a/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Episode.kt
+++ b/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Episode.kt
@@ -224,33 +224,6 @@ fun EpisodeItem(
                 }
             )
 
-            EpisodiveIconToggleButton(
-                modifier = Modifier.size(32.dp),
-                checked = episode.isSaved,
-                onCheckedChange = { onToggleSaved() },
-                colors = IconButtonDefaults.iconToggleButtonColors(
-                    checkedContainerColor = Color.Transparent,
-                    checkedContentColor = MaterialTheme.colorScheme.onPrimary,
-                    containerColor = Color.Transparent,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                ),
-                icon = {
-                    Icon(
-                        modifier = Modifier.size(16.dp),
-                        imageVector = EpisodiveIcons.Save,
-                        contentDescription = "Save",
-                        tint = MaterialTheme.colorScheme.onSurface
-                    )
-                },
-                checkedIcon = {
-                    Icon(
-                        modifier = Modifier.size(16.dp),
-                        imageVector = EpisodiveIcons.SaveFilled,
-                        contentDescription = "Unsave",
-                        tint = MaterialTheme.colorScheme.onSurface
-                    )
-                }
-            )
         }
     }
 }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -6,4 +6,8 @@
     <string name="core_ui_left">Left</string>
     <string name="core_ui_follow">Follow</string>
     <string name="core_ui_unfollow">Unfollow</string>
+    <string name="core_ui_snackbar_followed">팟캐스트를 구독했습니다</string>
+    <string name="core_ui_snackbar_unfollowed">구독을 해제했습니다</string>
+    <string name="core_ui_snackbar_unsaved">저장을 취소했습니다</string>
+    <string name="core_ui_snackbar_undo">실행 취소</string>
 </resources>

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
@@ -50,10 +50,11 @@ import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.liveEpisodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.core.ui.ChannelSection
+import io.jacob.episodive.core.ui.R as uiR
 import io.jacob.episodive.core.ui.EpisodesSection
 import io.jacob.episodive.core.ui.PlayingEpisodesSection
 import io.jacob.episodive.core.ui.PodcastsSection
-import kotlinx.coroutines.flow.collectLatest
+
 
 @Composable
 internal fun HomeRoute(
@@ -65,11 +66,18 @@ internal fun HomeRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
+    val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+
     LaunchedEffect(Unit) {
-        viewModel.effect.collectLatest { effect ->
+        viewModel.effect.collect { effect ->
             when (effect) {
                 is HomeEffect.NavigateToPodcast -> onPodcastClick(effect.podcastId)
                 is HomeEffect.NavigateToChannel -> onChannelClick(effect.channelId)
+                is HomeEffect.ShowUnsaveSnackbar -> {
+                    val undone = onShowSnackbar(unsavedMessage, undoLabel)
+                    if (undone) viewModel.sendAction(HomeAction.ToggleSavedEpisode(effect.episode))
+                }
             }
         }
     }

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeViewModel.kt
@@ -128,7 +128,10 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun toggleSavedEpisode(episode: Episode) = viewModelScope.launch {
-        saveEpisodeUseCase(episode)
+        val isSavedNow = saveEpisodeUseCase(episode)
+        if (!isSavedNow) {
+            _effect.emit(HomeEffect.ShowUnsaveSnackbar(episode))
+        }
     }
 
     private fun clickPodcast(podcastId: Long) = viewModelScope.launch {
@@ -174,4 +177,5 @@ sealed interface HomeAction {
 sealed interface HomeEffect {
     data class NavigateToPodcast(val podcastId: Long) : HomeEffect
     data class NavigateToChannel(val channelId: Long) : HomeEffect
+    data class ShowUnsaveSnackbar(val episode: Episode) : HomeEffect
 }

--- a/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryScreen.kt
@@ -65,6 +65,7 @@ import io.jacob.episodive.core.model.SelectableCategory
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.core.ui.CategoryButton
+import io.jacob.episodive.core.ui.R as uiR
 import io.jacob.episodive.core.ui.CategoryItem
 import io.jacob.episodive.core.ui.EpisodeDetailItem
 import io.jacob.episodive.core.ui.EpisodeItem
@@ -72,7 +73,7 @@ import io.jacob.episodive.core.ui.PlayedEpisodeItem
 import io.jacob.episodive.core.ui.PodcastDetailItem
 import io.jacob.episodive.core.ui.PodcastsSection
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collectLatest
+
 import kotlinx.coroutines.flow.flowOf
 
 @Composable
@@ -84,10 +85,17 @@ fun LibraryRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
+    val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+
     LaunchedEffect(Unit) {
-        viewModel.effect.collectLatest { effect ->
+        viewModel.effect.collect { effect ->
             when (effect) {
                 is LibraryEffect.NavigateToPodcast -> onPodcastClick(effect.podcastId)
+                is LibraryEffect.ShowUnsaveSnackbar -> {
+                    val undone = onShowSnackbar(unsavedMessage, undoLabel)
+                    if (undone) viewModel.sendAction(LibraryAction.ToggleSavedEpisode(effect.episode))
+                }
             }
         }
     }

--- a/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryViewModel.kt
@@ -268,7 +268,10 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun toggleSavedEpisode(episode: Episode) = viewModelScope.launch {
-        saveEpisodeUseCase(episode)
+        val isSavedNow = saveEpisodeUseCase(episode)
+        if (!isSavedNow) {
+            _effect.emit(LibraryEffect.ShowUnsaveSnackbar(episode))
+        }
     }
 
     private fun toggleFollowedPodcast(followedPodcast: Podcast) = viewModelScope.launch {
@@ -320,6 +323,7 @@ sealed interface LibraryAction {
 
 sealed interface LibraryEffect {
     data class NavigateToPodcast(val podcastId: Long) : LibraryEffect
+    data class ShowUnsaveSnackbar(val episode: Episode) : LibraryEffect
 }
 
 enum class LibrarySection { All, RecentlyListened, Liked, Saved, Followed, Preferred; }

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -46,7 +47,7 @@ import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.Progress
 import io.jacob.episodive.core.testing.model.episodeTestData
 import io.jacob.episodive.core.testing.model.podcastTestData
-import kotlinx.coroutines.flow.collectLatest
+import io.jacob.episodive.core.ui.R as uiR
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
@@ -54,13 +55,17 @@ fun PlayerBar(
     modifier: Modifier = Modifier,
     viewModel: PlayerViewModel = hiltViewModel(),
     onPodcastClick: (Long) -> Unit,
+    onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean = { _, _ -> false },
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     var isShowPlayer by remember { mutableStateOf(false) }
 
+    val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
+    val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+
     LaunchedEffect(Unit) {
-        viewModel.effect.collectLatest { effect ->
+        viewModel.effect.collect { effect ->
             when (effect) {
                 is PlayerEffect.NavigateToPodcast -> {}
                 is PlayerEffect.ShowPlayerBottomSheet -> {
@@ -69,6 +74,14 @@ fun PlayerBar(
 
                 is PlayerEffect.HidePlayerBottomSheet -> {
                     isShowPlayer = false
+                }
+
+                is PlayerEffect.ShowUnsaveSnackbar -> {
+                    if (!isShowPlayer) {
+                        val undone = onShowSnackbar(unsavedMessage, undoLabel)
+                        if (undone) viewModel.sendAction(PlayerAction.ToggleSavedEpisode(effect.episode))
+                    }
+                    // full player open → handled in PlayerBottomSheet
                 }
             }
         }

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
@@ -40,6 +40,9 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -70,6 +73,8 @@ import io.jacob.episodive.core.designsystem.component.EpisodiveDial
 import io.jacob.episodive.core.designsystem.component.EpisodiveDragHandle
 import io.jacob.episodive.core.designsystem.component.EpisodiveGradientBackground
 import io.jacob.episodive.core.designsystem.component.EpisodiveIconButton
+import io.jacob.episodive.core.designsystem.component.EpisodiveIconProgressButton
+import io.jacob.episodive.core.designsystem.component.EpisodiveSwipeDismissSnackbarHost
 import io.jacob.episodive.core.designsystem.component.EpisodiveIconToggleButton
 import io.jacob.episodive.core.designsystem.component.EpisodiveSeeker
 import io.jacob.episodive.core.designsystem.component.EpisodiveTextButton
@@ -82,6 +87,7 @@ import io.jacob.episodive.core.designsystem.theme.EpisodiveTheme
 import io.jacob.episodive.core.designsystem.theme.GradientColors
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Chapter
+import io.jacob.episodive.core.model.DownloadStatus
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.Progress
@@ -91,10 +97,11 @@ import io.jacob.episodive.core.model.mapper.toMediaTime
 import io.jacob.episodive.core.testing.model.episodeTestData
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestData
+import io.jacob.episodive.core.ui.R as uiR
 import io.jacob.episodive.core.ui.ChapterItem
 import io.jacob.episodive.core.ui.PodcastSimpleItem
 import io.jacob.episodive.core.ui.episodeItems
-import kotlinx.coroutines.flow.collectLatest
+
 import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 import kotlin.time.Duration.Companion.seconds
@@ -107,15 +114,29 @@ fun PlayerBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
+    val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+
     LaunchedEffect(Unit) {
-        viewModel.effect.collectLatest { effect ->
+        viewModel.effect.collect { effect ->
             when (effect) {
                 is PlayerEffect.NavigateToPodcast -> onPodcastClick(effect.podcastId)
                 is PlayerEffect.ShowPlayerBottomSheet -> {}
                 is PlayerEffect.HidePlayerBottomSheet -> sheetState.hide()
+                is PlayerEffect.ShowUnsaveSnackbar -> {
+                    val result = snackbarHostState.showSnackbar(
+                        message = unsavedMessage,
+                        actionLabel = undoLabel,
+                        duration = SnackbarDuration.Long,
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        viewModel.sendAction(PlayerAction.ToggleSavedEpisode(effect.episode))
+                    }
+                }
             }
         }
     }
@@ -140,6 +161,7 @@ fun PlayerBottomSheet(
             }
         }
 
+        Box {
         PlayerScreen(
             modifier = Modifier,
             podcast = s.podcast,
@@ -171,6 +193,12 @@ fun PlayerBottomSheet(
             onToggleFollowedPodcast = { viewModel.sendAction(PlayerAction.ToggleFollowedPodcast(it)) },
             cue = s.cue,
         )
+
+            EpisodiveSwipeDismissSnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
     }
 }
 
@@ -319,6 +347,8 @@ internal fun PlayerScreen(
                     ControlPanelBottom(
                         isPlaying = isPlaying,
                         isSaved = nowPlaying.isSaved,
+                        isDownloading = nowPlaying.isDownloading,
+                        downloadProgress = nowPlaying.downloadProgress,
                         onPlayOrPause = onPlayOrPause,
                         onBackward = onBackward,
                         onForward = onForward,
@@ -516,6 +546,8 @@ private fun ControlPanelBottom(
     modifier: Modifier = Modifier,
     isPlaying: Boolean,
     isSaved: Boolean = false,
+    isDownloading: Boolean = false,
+    downloadProgress: Float = 0f,
     onPlayOrPause: () -> Unit = {},
     onBackward: () -> Unit = {},
     onForward: () -> Unit = {},
@@ -634,31 +666,50 @@ private fun ControlPanelBottom(
                 )
             }
 
-            EpisodiveIconToggleButton(
-                modifier = Modifier.size(32.dp),
-                checked = isSaved,
-                onCheckedChange = { onToggleSave() },
-                colors = IconButtonDefaults.iconToggleButtonColors(
-                    checkedContainerColor = Color.Transparent,
-                    checkedContentColor = MaterialTheme.colorScheme.onSurface,
-                    containerColor = Color.Transparent,
-                    contentColor = MaterialTheme.colorScheme.onSurface,
-                ),
-                icon = {
-                    Icon(
-                        modifier = Modifier.size(24.dp),
-                        imageVector = EpisodiveIcons.Download,
-                        contentDescription = "Save",
-                    )
-                },
-                checkedIcon = {
-                    Icon(
-                        modifier = Modifier.size(24.dp),
-                        imageVector = EpisodiveIcons.DownloadDone,
-                        contentDescription = "Unsave",
-                    )
-                }
-            )
+            if (isDownloading) {
+                EpisodiveIconProgressButton(
+                    modifier = Modifier.size(32.dp),
+                    onClick = { onToggleSave() },
+                    progress = downloadProgress,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                    icon = {
+                        Icon(
+                            modifier = Modifier.size(24.dp),
+                            imageVector = EpisodiveIcons.DownloadDone,
+                            contentDescription = "Downloading",
+                        )
+                    },
+                )
+            } else {
+                EpisodiveIconToggleButton(
+                    modifier = Modifier.size(32.dp),
+                    checked = isSaved,
+                    onCheckedChange = { onToggleSave() },
+                    colors = IconButtonDefaults.iconToggleButtonColors(
+                        checkedContainerColor = Color.Transparent,
+                        checkedContentColor = MaterialTheme.colorScheme.onSurface,
+                        containerColor = Color.Transparent,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                    icon = {
+                        Icon(
+                            modifier = Modifier.size(24.dp),
+                            imageVector = EpisodiveIcons.Download,
+                            contentDescription = "Save",
+                        )
+                    },
+                    checkedIcon = {
+                        Icon(
+                            modifier = Modifier.size(24.dp),
+                            imageVector = EpisodiveIcons.DownloadDone,
+                            contentDescription = "Unsave",
+                        )
+                    }
+                )
+            }
 
             EpisodiveIconButton(
                 modifier = Modifier.size(32.dp),

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
@@ -285,12 +285,18 @@ class PlayerViewModel @Inject constructor(
     private fun toggleCurrentSavedEpisode() = viewModelScope.launch {
         val currentState = state.value
         if (currentState is PlayerState.Success) {
-            saveEpisodeUseCase(currentState.nowPlaying)
+            val isSavedNow = saveEpisodeUseCase(currentState.nowPlaying)
+            if (!isSavedNow) {
+                _effect.emit(PlayerEffect.ShowUnsaveSnackbar(currentState.nowPlaying))
+            }
         }
     }
 
     private fun toggleSavedEpisode(episode: Episode) = viewModelScope.launch {
-        saveEpisodeUseCase(episode)
+        val isSavedNow = saveEpisodeUseCase(episode)
+        if (!isSavedNow) {
+            _effect.emit(PlayerEffect.ShowUnsaveSnackbar(episode))
+        }
     }
 
     private fun toggleFollowedPodcast(podcast: Podcast) = viewModelScope.launch {
@@ -349,6 +355,7 @@ sealed interface PlayerEffect {
     data class NavigateToPodcast(val podcastId: Long) : PlayerEffect
     data object ShowPlayerBottomSheet : PlayerEffect
     data object HidePlayerBottomSheet : PlayerEffect
+    data class ShowUnsaveSnackbar(val episode: Episode) : PlayerEffect
 }
 
 private data class LastPlaySnapshot(

--- a/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastScreen.kt
+++ b/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,6 +55,7 @@ import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestData
 import io.jacob.episodive.core.ui.EpisodeItem
 import kotlinx.coroutines.flow.Flow
+
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import io.jacob.episodive.core.ui.R as uiR
@@ -66,6 +68,27 @@ internal fun PodcastRoute(
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    val followedMessage = stringResource(uiR.string.core_ui_snackbar_followed)
+    val unfollowedMessage = stringResource(uiR.string.core_ui_snackbar_unfollowed)
+    val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
+    val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is PodcastEffect.ShowFollowSnackbar -> {
+                    val message = if (effect.isFollowed) followedMessage else unfollowedMessage
+                    val undone = onShowSnackbar(message, undoLabel)
+                    if (undone) viewModel.sendAction(PodcastAction.ToggleFollowed)
+                }
+                is PodcastEffect.ShowUnsaveSnackbar -> {
+                    val undone = onShowSnackbar(unsavedMessage, undoLabel)
+                    if (undone) viewModel.sendAction(PodcastAction.ToggleSavedEpisode(effect.episode))
+                }
+            }
+        }
+    }
 
     when (val s = state) {
         is PodcastState.Loading -> LoadingScreen()

--- a/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastViewModel.kt
+++ b/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastViewModel.kt
@@ -17,6 +17,7 @@ import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
@@ -59,6 +60,9 @@ class PodcastViewModel @AssistedInject constructor(
 
     private val _action = MutableSharedFlow<PodcastAction>(extraBufferCapacity = 1)
 
+    private val _effect = MutableSharedFlow<PodcastEffect>(extraBufferCapacity = 1)
+    val effect = _effect.asSharedFlow()
+
     init {
         handleActions()
     }
@@ -79,7 +83,8 @@ class PodcastViewModel @AssistedInject constructor(
     }
 
     private fun toggleFollowed() = viewModelScope.launch {
-        toggleFollowedUseCase(id)
+        val isFollowedNow = toggleFollowedUseCase(id)
+        _effect.emit(PodcastEffect.ShowFollowSnackbar(isFollowedNow))
     }
 
     private fun playEpisode(episode: Episode, visibleEpisodes: List<Episode>) =
@@ -98,8 +103,16 @@ class PodcastViewModel @AssistedInject constructor(
     }
 
     private fun toggleSavedEpisode(episode: Episode) = viewModelScope.launch {
-        saveEpisodeUseCase(episode)
+        val isSavedNow = saveEpisodeUseCase(episode)
+        if (!isSavedNow) {
+            _effect.emit(PodcastEffect.ShowUnsaveSnackbar(episode))
+        }
     }
+}
+
+sealed interface PodcastEffect {
+    data class ShowFollowSnackbar(val isFollowed: Boolean) : PodcastEffect
+    data class ShowUnsaveSnackbar(val episode: Episode) : PodcastEffect
 }
 
 sealed interface PodcastState {


### PR DESCRIPTION
## 변경 사항
- 수직 드래그로 dismiss 가능한 커스텀 `EpisodiveSwipeDismissSnackbarHost` 컴포넌트 추가
- 팟캐스트 구독/해제 시 "실행 취소" Undo 스낵바 표시 (PodcastScreen)
- 에피소드 저장 해제 시 Undo 스낵바 표시 (Home, Podcast, Library, Player 전체)
- 플레이어 다운로드 중 `ControlPanelBottom`에 진행률 아이콘 표시 (Spotify 스타일)
- 스낵바 위치 보정: 미니플레이어 위에 표시, 풀 플레이어 내부 별도 SnackbarHost
- DB 마이그레이션 10→11: `EpisodeWithExtrasView`에 `downloadedSize`/`totalSize` 컬럼 추가
- `Episode` 모델에 `downloadProgress`, `isDownloading` computed property 추가
- `EpisodeItem`에서 저장 아이콘 제거 (플레이어 전용으로 이동)

## 테스트
- 팟캐스트 상세에서 구독/해제 → 스낵바 + Undo 동작 확인
- 에피소드 저장 해제 → 스낵바 + Undo 동작 확인 (Home, Library, Player)
- 풀 플레이어에서 저장 해제 → 플레이어 내부 스낵바 표시 확인
- 미니플레이어 표시 중 스낵바가 미니플레이어 위에 위치하는지 확인
- 스낵바 수직 드래그 dismiss 동작 확인
- 기존 유닛 테스트 전체 통과 확인