### PR TITLE
feat: 슬립 타이머 기능 추가 (#73)

### DIFF
--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/PlayerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/PlayerRepositoryImpl.kt
@@ -98,6 +98,10 @@ class PlayerRepositoryImpl @Inject constructor(
         playerDataSource.setSpeed(speed)
     }
 
+    override fun setVolume(volume: Float) {
+        playerDataSource.setVolume(volume)
+    }
+
     override fun addTrack(episode: Episode, index: Int?) {
         playerDataSource.addTrack(episode, index)
     }

--- a/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/icon/EpisodiveIcons.kt
+++ b/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/icon/EpisodiveIcons.kt
@@ -28,6 +28,7 @@ import io.jacob.episodive.core.designsystem.icon.tabler.LetterISmall
 import io.jacob.episodive.core.designsystem.icon.tabler.LetterXSmall
 import io.jacob.episodive.core.designsystem.icon.tabler.List
 import io.jacob.episodive.core.designsystem.icon.tabler.ListNumbers
+import io.jacob.episodive.core.designsystem.icon.tabler.Moon
 import io.jacob.episodive.core.designsystem.icon.tabler.PhotoExclamation
 import io.jacob.episodive.core.designsystem.icon.tabler.PlayerPause
 import io.jacob.episodive.core.designsystem.icon.tabler.PlayerPlay
@@ -73,6 +74,7 @@ object EpisodiveIcons {
     val LikeFilled = Tabler.HeartFilled
     val List = Tabler.List
     val ListNumbered = Tabler.ListNumbers
+    val Moon = Tabler.Moon
     val MoreVert = Tabler.DotsVertical
     val Owner = Tabler.CreativeCommonsBy
     val Pause = Tabler.PlayerPause

--- a/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/icon/tabler/Moon.kt
+++ b/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/icon/tabler/Moon.kt
@@ -1,0 +1,41 @@
+package io.jacob.episodive.core.designsystem.icon.tabler
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val Tabler.Moon: ImageVector
+    get() {
+        if (_Moon != null) {
+            return _Moon!!
+        }
+        _Moon = ImageVector.Builder(
+            name = "Moon",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                stroke = SolidColor(Color.Black),
+                strokeLineWidth = 2f,
+                strokeLineCap = StrokeCap.Round,
+                strokeLineJoin = StrokeJoin.Round
+            ) {
+                moveTo(12f, 3f)
+                curveToRelative(0.132f, 0f, 0.263f, 0f, 0.393f, 0f)
+                arcToRelative(7.5f, 7.5f, 0f, isMoreThanHalf = false, isPositiveArc = false, 7.92f, 12.446f)
+                arcToRelative(9f, 9f, 0f, isMoreThanHalf = true, isPositiveArc = true, -8.313f, -12.454f)
+                close()
+            }
+        }.build()
+
+        return _Moon!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Moon: ImageVector? = null

--- a/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/repository/PlayerRepository.kt
+++ b/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/repository/PlayerRepository.kt
@@ -29,6 +29,7 @@ interface PlayerRepository {
     fun changeRepeat()
     fun setRepeat(repeat: Repeat)
     fun setSpeed(speed: Float)
+    fun setVolume(volume: Float)
     fun addTrack(episode: Episode, index: Int? = null)
     fun addTrack(episodes: List<Episode>, index: Int? = null)
     fun addClipTrack(episode: Episode, index: Int? = null)

--- a/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSource.kt
+++ b/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSource.kt
@@ -27,6 +27,7 @@ interface PlayerDataSource {
     fun setRepeat(repeat: Int)
     fun changeRepeat()
     fun setSpeed(speed: Float)
+    fun setVolume(volume: Float)
     fun addTrack(episode: Episode, index: Int? = null)
     fun addTrack(episodes: List<Episode>, index: Int? = null)
     fun addClipTrack(episode: Episode, index: Int? = null)

--- a/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
+++ b/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
@@ -353,6 +353,10 @@ class PlayerDataSourceImpl @Inject constructor(
         _speed.value = safeSpeed
     }
 
+    override fun setVolume(volume: Float) {
+        player.volume = volume.coerceIn(0f, 1f)
+    }
+
     override fun addTrack(episode: Episode, index: Int?) {
         val mediaItem = episode.toMediaItem(isClip = false)
 

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
@@ -63,6 +63,7 @@ fun PlayerBar(
 
     val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
     val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+    val sleepTimerExpiredMessage = stringResource(R.string.feature_player_sleep_timer_expired)
 
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
@@ -85,7 +86,9 @@ fun PlayerBar(
                 }
 
                 is PlayerEffect.SleepTimerExpired -> {
-                    // handled in PlayerBottomSheet
+                    if (!isShowPlayer) {
+                        onShowSnackbar(sleepTimerExpiredMessage, null)
+                    }
                 }
             }
         }

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
@@ -83,6 +83,10 @@ fun PlayerBar(
                     }
                     // full player open → handled in PlayerBottomSheet
                 }
+
+                is PlayerEffect.SleepTimerExpired -> {
+                    // handled in PlayerBottomSheet
+                }
             }
         }
     }

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -59,6 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -120,6 +122,7 @@ fun PlayerBottomSheet(
 
     val unsavedMessage = stringResource(uiR.string.core_ui_snackbar_unsaved)
     val undoLabel = stringResource(uiR.string.core_ui_snackbar_undo)
+    val sleepTimerExpiredMessage = stringResource(R.string.feature_player_sleep_timer_expired)
 
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
@@ -136,6 +139,13 @@ fun PlayerBottomSheet(
                     if (result == SnackbarResult.ActionPerformed) {
                         viewModel.sendAction(PlayerAction.ToggleSavedEpisode(effect.episode))
                     }
+                }
+
+                is PlayerEffect.SleepTimerExpired -> {
+                    snackbarHostState.showSnackbar(
+                        message = sleepTimerExpiredMessage,
+                        duration = SnackbarDuration.Short,
+                    )
                 }
             }
         }
@@ -192,6 +202,10 @@ fun PlayerBottomSheet(
             chapters = s.chapters,
             onToggleFollowedPodcast = { viewModel.sendAction(PlayerAction.ToggleFollowedPodcast(it)) },
             cue = s.cue,
+            sleepTimerRemainingMs = s.sleepTimerRemainingMs,
+            onSetSleepTimer = { viewModel.sendAction(PlayerAction.SetSleepTimer(it)) },
+            onCancelSleepTimer = { viewModel.sendAction(PlayerAction.CancelSleepTimer) },
+            onSleepTimerEndOfEpisode = { viewModel.sendAction(PlayerAction.SleepTimerEndOfEpisode) },
         )
 
             EpisodiveSwipeDismissSnackbarHost(
@@ -231,11 +245,16 @@ internal fun PlayerScreen(
     chapters: List<Chapter>,
     onToggleFollowedPodcast: (Podcast) -> Unit,
     cue: String,
+    sleepTimerRemainingMs: Long? = null,
+    onSetSleepTimer: (Long) -> Unit = {},
+    onCancelSleepTimer: () -> Unit = {},
+    onSleepTimerEndOfEpisode: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
     var showSpeedSheet by remember { mutableStateOf(false) }
     var showPlaylistSheet by remember { mutableStateOf(false) }
+    var showSleepTimerSheet by remember { mutableStateOf(false) }
     var chapterIndex by remember { mutableStateOf(0) }
     var dominantColor by remember { mutableStateOf(Color.DarkGray) }
 
@@ -356,6 +375,8 @@ internal fun PlayerScreen(
                         onNext = onNext,
                         onSpeed = { showSpeedSheet = true },
                         speed = speed,
+                        onSleepTimer = { showSleepTimerSheet = true },
+                        sleepTimerRemainingMs = sleepTimerRemainingMs,
                         onList = { showPlaylistSheet = true },
                         onToggleSave = onToggleSave,
                     )
@@ -412,6 +433,17 @@ internal fun PlayerScreen(
             onToggleLikedEpisode = onToggleLikedEpisode,
             onToggleSavedEpisode = onToggleSavedEpisode,
             onDismiss = { showPlaylistSheet = false }
+        )
+    }
+
+    if (showSleepTimerSheet) {
+        SleepTimerSheet(
+            remainingMs = sleepTimerRemainingMs,
+            isPlaying = isPlaying,
+            onSetTimer = { onSetSleepTimer(it) },
+            onEndOfEpisode = onSleepTimerEndOfEpisode,
+            onCancel = onCancelSleepTimer,
+            onDismiss = { showSleepTimerSheet = false },
         )
     }
 }
@@ -555,6 +587,8 @@ private fun ControlPanelBottom(
     onNext: () -> Unit = {},
     onSpeed: () -> Unit = {},
     speed: Float,
+    onSleepTimer: () -> Unit = {},
+    sleepTimerRemainingMs: Long? = null,
     onList: () -> Unit = {},
     onToggleSave: () -> Unit = {},
 ) {
@@ -665,6 +699,31 @@ private fun ControlPanelBottom(
                     text = "${decimalFormat.format(speed)}x"
                 )
             }
+
+            EpisodiveIconButton(
+                modifier = Modifier.size(32.dp),
+                onClick = onSleepTimer,
+                icon = {
+                    val moonTint = when {
+                        sleepTimerRemainingMs == null -> MaterialTheme.colorScheme.onSurface
+                        sleepTimerRemainingMs <= PlayerViewModel.FADE_OUT_DURATION_MS -> {
+                            val fraction = sleepTimerRemainingMs / PlayerViewModel.FADE_OUT_DURATION_MS.toFloat()
+                            lerp(
+                                MaterialTheme.colorScheme.onSurface,
+                                MaterialTheme.colorScheme.primary,
+                                fraction,
+                            )
+                        }
+                        else -> MaterialTheme.colorScheme.primary
+                    }
+                    Icon(
+                        modifier = Modifier.size(24.dp),
+                        imageVector = EpisodiveIcons.Moon,
+                        contentDescription = stringResource(R.string.feature_player_sleep_timer),
+                        tint = moonTint,
+                    )
+                }
+            )
 
             if (isDownloading) {
                 EpisodiveIconProgressButton(
@@ -923,6 +982,158 @@ private fun PlaylistSheet(
                 onEpisodeClick = onEpisodeClick,
                 onToggleLikedEpisode = onToggleLikedEpisode,
                 onToggleSavedEpisode = onToggleSavedEpisode,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SleepTimerSheet(
+    modifier: Modifier = Modifier,
+    remainingMs: Long?,
+    isPlaying: Boolean,
+    onSetTimer: (Long) -> Unit = {},
+    onEndOfEpisode: () -> Unit = {},
+    onCancel: () -> Unit = {},
+    onDismiss: () -> Unit = {},
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val requiresPlaybackMessage = stringResource(R.string.feature_player_sleep_timer_requires_playback)
+
+    fun handleAction(action: () -> Unit) {
+        if (isPlaying) {
+            action()
+        } else {
+            scope.launch {
+                snackbarHostState.currentSnackbarData?.dismiss()
+                snackbarHostState.showSnackbar(
+                    message = requiresPlaybackMessage,
+                    duration = SnackbarDuration.Short,
+                )
+            }
+        }
+    }
+
+    val timerPresets = remember {
+        listOf(
+            30L * 1000,
+            5L * 60 * 1000,
+            10L * 60 * 1000,
+            15L * 60 * 1000,
+            30L * 60 * 1000,
+            45L * 60 * 1000,
+            60L * 60 * 1000,
+        )
+    }
+    // TODO: 30초 프리셋은 테스트용. 출시 시 제거
+    val isActive = remainingMs != null
+
+    ModalBottomSheet(
+        modifier = modifier.fillMaxWidth(),
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = { EpisodiveDragHandle() }
+    ) {
+        Box {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateContentSize(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.feature_player_sleep_timer),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                val displayMs = remainingMs ?: 0L
+                val minutes = displayMs / 1000 / 60
+                val seconds = (displayMs / 1000) % 60
+                val timerColor = when {
+                    !isActive -> MaterialTheme.colorScheme.onSurface
+                    displayMs <= PlayerViewModel.FADE_OUT_DURATION_MS -> {
+                        val fraction = displayMs / PlayerViewModel.FADE_OUT_DURATION_MS.toFloat()
+                        lerp(
+                            MaterialTheme.colorScheme.onSurface,
+                            MaterialTheme.colorScheme.primary,
+                            fraction,
+                        )
+                    }
+                    else -> MaterialTheme.colorScheme.primary
+                }
+                Text(
+                    text = String.format("%d:%02d", minutes, seconds),
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = timerColor,
+                )
+
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    timerPresets.forEach { durationMs ->
+                        val totalSeconds = (durationMs / 1000).toInt()
+                        val label = if (totalSeconds < 60) "${totalSeconds}s"
+                        else stringResource(R.string.feature_player_sleep_timer_minutes, totalSeconds / 60)
+                        EpisodiveButton(
+                            modifier = Modifier.size(48.dp),
+                            onClick = { handleAction { onSetTimer(durationMs) } },
+                            shape = CircleShape,
+                            contentPadding = PaddingValues(0.dp),
+                            buttonColors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        ) {
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.titleSmall,
+                            )
+                        }
+                    }
+                }
+
+                EpisodiveButton(
+                    onClick = { handleAction { onEndOfEpisode() } },
+                    contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+                    buttonColors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.feature_player_sleep_timer_end_of_episode),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+
+                AnimatedVisibility(visible = isActive) {
+                    EpisodiveButton(
+                        onClick = { onCancel() },
+                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+                        buttonColors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.feature_player_sleep_timer_cancel),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            EpisodiveSwipeDismissSnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
     }

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
@@ -25,7 +25,12 @@ import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.Progress
 import io.jacob.episodive.core.model.Repeat
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -88,6 +93,9 @@ class PlayerViewModel @Inject constructor(
         }
 
 
+    private var sleepTimerJob: Job? = null
+    private val _sleepTimerRemainingMs = MutableStateFlow<Long?>(null)
+
     val state: StateFlow<PlayerState> = combineTyped(
         podcast,
         nowPlaying,
@@ -98,7 +106,8 @@ class PlayerViewModel @Inject constructor(
         playerRepository.speed,
         chapters,
         playerRepository.cue,
-    ) { podcast, nowPlaying, playlist, indexOfList, progress, isPlaying, speed, chapters, cue ->
+        _sleepTimerRemainingMs,
+    ) { podcast, nowPlaying, playlist, indexOfList, progress, isPlaying, speed, chapters, cue, sleepTimerRemainingMs ->
         if (podcast != null && nowPlaying != null) {
             PlayerState.Success(
                 podcast = podcast,
@@ -110,6 +119,7 @@ class PlayerViewModel @Inject constructor(
                 speed = speed,
                 chapters = chapters,
                 cue = cue,
+                sleepTimerRemainingMs = sleepTimerRemainingMs,
             ) as PlayerState
         } else {
             PlayerState.Error("podcast or nowPlaying is null")
@@ -189,7 +199,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     private fun handleActions() = viewModelScope.launch {
-        _action.collectLatest { action ->
+        _action.collect { action ->
             when (action) {
                 is PlayerAction.PlayOrPause -> playOrPause()
                 is PlayerAction.Next -> next()
@@ -210,6 +220,9 @@ class PlayerViewModel @Inject constructor(
                 is PlayerAction.ToggleFollowedPodcast -> toggleFollowedPodcast(action.podcast)
                 is PlayerAction.ExpandPlayer -> expandPlayer()
                 is PlayerAction.CollapsePlayer -> collapsePlayer()
+                is PlayerAction.SetSleepTimer -> startSleepTimer(action.durationMs)
+                is PlayerAction.CancelSleepTimer -> cancelSleepTimer()
+                is PlayerAction.SleepTimerEndOfEpisode -> startEndOfEpisodeTimer()
             }
         }
     }
@@ -310,6 +323,72 @@ class PlayerViewModel @Inject constructor(
     private fun collapsePlayer() = viewModelScope.launch {
         _effect.emit(PlayerEffect.HidePlayerBottomSheet)
     }
+
+    private fun startSleepTimer(durationMs: Long) {
+        sleepTimerJob?.cancel()
+        playerRepository.setVolume(1f)
+        sleepTimerJob = viewModelScope.launch {
+            _sleepTimerRemainingMs.value = durationMs
+            val endTime = timeProvider.currentTimeMillis() + durationMs
+            while (isActive) {
+                val remaining = endTime - timeProvider.currentTimeMillis()
+                if (remaining <= 0) {
+                    playerRepository.setVolume(0f)
+                    playerRepository.pause()
+                    playerRepository.setVolume(1f)
+                    _sleepTimerRemainingMs.value = null
+                    _effect.emit(PlayerEffect.SleepTimerExpired)
+                    break
+                }
+                if (remaining <= FADE_OUT_DURATION_MS) {
+                    val volume = remaining.toFloat() / FADE_OUT_DURATION_MS
+                    playerRepository.setVolume(volume)
+                }
+                _sleepTimerRemainingMs.value = remaining
+                delay(1000)
+            }
+        }
+    }
+
+    private fun startEndOfEpisodeTimer() {
+        sleepTimerJob?.cancel()
+        playerRepository.setVolume(1f)
+        sleepTimerJob = viewModelScope.launch {
+            val startEpisodeId = nowPlaying.value?.id ?: return@launch
+            val duration = playerRepository.progress.first().duration.inWholeMilliseconds
+            if (duration <= 0) return@launch
+
+            combine(playerRepository.progress, nowPlaying) { progress, episode ->
+                progress to episode
+            }.takeWhile { (progress, episode) ->
+                val remaining = progress.duration.inWholeMilliseconds - progress.position.inWholeMilliseconds
+                val sameEpisode = episode?.id == startEpisodeId
+                _sleepTimerRemainingMs.value = remaining.coerceAtLeast(0)
+                if (remaining <= FADE_OUT_DURATION_MS) {
+                    val volume = remaining.toFloat() / FADE_OUT_DURATION_MS
+                    playerRepository.setVolume(volume.coerceIn(0f, 1f))
+                }
+                sameEpisode && remaining > 500
+            }.collect {}
+
+            playerRepository.setVolume(0f)
+            playerRepository.pause()
+            playerRepository.setVolume(1f)
+            _sleepTimerRemainingMs.value = null
+            _effect.emit(PlayerEffect.SleepTimerExpired)
+        }
+    }
+
+    private fun cancelSleepTimer() {
+        sleepTimerJob?.cancel()
+        sleepTimerJob = null
+        _sleepTimerRemainingMs.value = null
+        playerRepository.setVolume(1f)
+    }
+
+    companion object {
+        internal const val FADE_OUT_DURATION_MS = 15_000L
+    }
 }
 
 sealed interface PlayerState {
@@ -324,6 +403,7 @@ sealed interface PlayerState {
         val speed: Float,
         val chapters: List<Chapter>,
         val cue: String,
+        val sleepTimerRemainingMs: Long? = null,
     ) : PlayerState
 
     data class Error(val message: String) : PlayerState
@@ -349,6 +429,9 @@ sealed interface PlayerAction {
     data class ToggleFollowedPodcast(val podcast: Podcast) : PlayerAction
     data object ExpandPlayer : PlayerAction
     data object CollapsePlayer : PlayerAction
+    data class SetSleepTimer(val durationMs: Long) : PlayerAction
+    data object CancelSleepTimer : PlayerAction
+    data object SleepTimerEndOfEpisode : PlayerAction
 }
 
 sealed interface PlayerEffect {
@@ -356,6 +439,7 @@ sealed interface PlayerEffect {
     data object ShowPlayerBottomSheet : PlayerEffect
     data object HidePlayerBottomSheet : PlayerEffect
     data class ShowUnsaveSnackbar(val episode: Episode) : PlayerEffect
+    data object SleepTimerExpired : PlayerEffect
 }
 
 private data class LastPlaySnapshot(

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
@@ -326,64 +326,74 @@ class PlayerViewModel @Inject constructor(
 
     private fun startSleepTimer(durationMs: Long) {
         sleepTimerJob?.cancel()
-        playerRepository.setVolume(1f)
         sleepTimerJob = viewModelScope.launch {
-            _sleepTimerRemainingMs.value = durationMs
-            val endTime = timeProvider.currentTimeMillis() + durationMs
-            while (isActive) {
-                val remaining = endTime - timeProvider.currentTimeMillis()
-                if (remaining <= 0) {
-                    playerRepository.setVolume(0f)
-                    playerRepository.pause()
-                    playerRepository.setVolume(1f)
-                    _sleepTimerRemainingMs.value = null
-                    _effect.emit(PlayerEffect.SleepTimerExpired)
-                    break
+            try {
+                playerRepository.setVolume(1f)
+                _sleepTimerRemainingMs.value = durationMs
+                val endTime = timeProvider.currentTimeMillis() + durationMs
+                while (isActive) {
+                    val remaining = endTime - timeProvider.currentTimeMillis()
+                    if (remaining <= 0) {
+                        playerRepository.setVolume(0f)
+                        playerRepository.pause()
+                        _effect.emit(PlayerEffect.SleepTimerExpired)
+                        break
+                    }
+                    if (remaining <= FADE_OUT_DURATION_MS) {
+                        val volume = remaining.toFloat() / FADE_OUT_DURATION_MS
+                        playerRepository.setVolume(volume)
+                    }
+                    _sleepTimerRemainingMs.value = remaining
+                    delay(1000)
                 }
-                if (remaining <= FADE_OUT_DURATION_MS) {
-                    val volume = remaining.toFloat() / FADE_OUT_DURATION_MS
-                    playerRepository.setVolume(volume)
-                }
-                _sleepTimerRemainingMs.value = remaining
-                delay(1000)
+            } finally {
+                playerRepository.setVolume(1f)
+                _sleepTimerRemainingMs.value = null
             }
         }
     }
 
     private fun startEndOfEpisodeTimer() {
         sleepTimerJob?.cancel()
-        playerRepository.setVolume(1f)
         sleepTimerJob = viewModelScope.launch {
-            val startEpisodeId = nowPlaying.value?.id ?: return@launch
-            val duration = playerRepository.progress.first().duration.inWholeMilliseconds
-            if (duration <= 0) return@launch
+            try {
+                playerRepository.setVolume(1f)
+                val startEpisodeId = nowPlaying.value?.id ?: return@launch
+                val duration = playerRepository.progress.first().duration.inWholeMilliseconds
+                if (duration <= 0) return@launch
 
-            combine(playerRepository.progress, nowPlaying) { progress, episode ->
-                progress to episode
-            }.takeWhile { (progress, episode) ->
-                val remaining = progress.duration.inWholeMilliseconds - progress.position.inWholeMilliseconds
-                val sameEpisode = episode?.id == startEpisodeId
-                _sleepTimerRemainingMs.value = remaining.coerceAtLeast(0)
-                if (remaining <= FADE_OUT_DURATION_MS) {
-                    val volume = remaining.toFloat() / FADE_OUT_DURATION_MS
-                    playerRepository.setVolume(volume.coerceIn(0f, 1f))
+                var timerExpired = false
+                combine(playerRepository.progress, nowPlaying) { progress, episode ->
+                    progress to episode
+                }.takeWhile { (progress, episode) ->
+                    val remaining = progress.duration.inWholeMilliseconds - progress.position.inWholeMilliseconds
+                    val sameEpisode = episode?.id == startEpisodeId
+                    if (!sameEpisode) return@takeWhile false
+                    _sleepTimerRemainingMs.value = remaining.coerceAtLeast(0)
+                    if (remaining <= FADE_OUT_DURATION_MS) {
+                        val volume = remaining.toFloat() / FADE_OUT_DURATION_MS
+                        playerRepository.setVolume(volume.coerceIn(0f, 1f))
+                    }
+                    val shouldContinue = remaining > 500
+                    if (!shouldContinue) timerExpired = true
+                    shouldContinue
+                }.collect {}
+
+                if (timerExpired) {
+                    playerRepository.setVolume(0f)
+                    playerRepository.pause()
+                    _effect.emit(PlayerEffect.SleepTimerExpired)
                 }
-                sameEpisode && remaining > 500
-            }.collect {}
-
-            playerRepository.setVolume(0f)
-            playerRepository.pause()
-            playerRepository.setVolume(1f)
-            _sleepTimerRemainingMs.value = null
-            _effect.emit(PlayerEffect.SleepTimerExpired)
+            } finally {
+                playerRepository.setVolume(1f)
+                _sleepTimerRemainingMs.value = null
+            }
         }
     }
 
     private fun cancelSleepTimer() {
         sleepTimerJob?.cancel()
         sleepTimerJob = null
-        _sleepTimerRemainingMs.value = null
-        playerRepository.setVolume(1f)
     }
 
     companion object {

--- a/feature/player/src/main/res/values-ko/strings.xml
+++ b/feature/player/src/main/res/values-ko/strings.xml
@@ -6,4 +6,10 @@
     <string name="feature_player_speed">배속</string>
     <string name="feature_player_show_more">더보기</string>
     <string name="feature_player_show_less">간단히</string>
+    <string name="feature_player_sleep_timer">슬립 타이머</string>
+    <string name="feature_player_sleep_timer_cancel">타이머 취소</string>
+    <string name="feature_player_sleep_timer_end_of_episode">에피소드 끝까지</string>
+    <string name="feature_player_sleep_timer_expired">슬립 타이머가 종료되었습니다</string>
+    <string name="feature_player_sleep_timer_minutes">%d</string>
+    <string name="feature_player_sleep_timer_requires_playback">재생 중에만 슬립 타이머를 설정할 수 있습니다</string>
 </resources>

--- a/feature/player/src/main/res/values/strings.xml
+++ b/feature/player/src/main/res/values/strings.xml
@@ -6,4 +6,10 @@
     <string name="feature_player_speed">x</string>
     <string name="feature_player_show_more">See More</string>
     <string name="feature_player_show_less">Show Less</string>
+    <string name="feature_player_sleep_timer">Sleep Timer</string>
+    <string name="feature_player_sleep_timer_cancel">Cancel Timer</string>
+    <string name="feature_player_sleep_timer_end_of_episode">End of Episode</string>
+    <string name="feature_player_sleep_timer_expired">Sleep timer expired</string>
+    <string name="feature_player_sleep_timer_minutes">%d</string>
+    <string name="feature_player_sleep_timer_requires_playback">Play an episode first to set a sleep timer</string>
 </resources>

--- a/feature/player/src/test/kotlin/io/jacob/episodive/feature/player/PlayerViewModelTest.kt
+++ b/feature/player/src/test/kotlin/io/jacob/episodive/feature/player/PlayerViewModelTest.kt
@@ -438,4 +438,96 @@ class PlayerViewModelTest {
 
             coVerify(exactly = 0) { restoreLastPlayStateUseCase() }
         }
+
+    // --- Sleep Timer Tests ---
+
+    @Test
+    fun `Given SetSleepTimer action, When timer expires, Then pause is called and SleepTimerExpired effect is emitted`() =
+        runTest {
+            setupDefaultMocks()
+            every { timeProvider.currentTimeMillis() } returnsMany listOf(0L, 60_001L)
+
+            val viewModel = createViewModel()
+
+            viewModel.effect.test {
+                viewModel.sendAction(PlayerAction.SetSleepTimer(60_000L))
+                assertEquals(PlayerEffect.SleepTimerExpired, awaitItem())
+            }
+
+            verify { playerRepository.pause() }
+        }
+
+    @Test
+    fun `Given SetSleepTimer action, When timer expires, Then sleepTimerRemainingMs becomes null in state`() =
+        runTest {
+            setupPlayerRepositoryMocks()
+            val episode = episodeTestData
+            val podcast = podcastTestData
+
+            every { getNowPlayingUseCase() } returns flowOf(episode)
+            every { getPodcastUseCase(episode.feedId) } returns flowOf(podcast)
+            every { getPlaylistUseCase() } returns flowOf(listOf(episode))
+            every { getUserDataUseCase() } returns flowOf(UserData(speed = 1.0f))
+            every { timeProvider.currentTimeMillis() } returnsMany listOf(0L, 60_001L)
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is PlayerState.Success)
+                assertEquals(null, (state as PlayerState.Success).sleepTimerRemainingMs)
+            }
+
+            viewModel.sendAction(PlayerAction.SetSleepTimer(60_000L))
+
+            // After expiry, sleepTimerRemainingMs should be null
+            val finalState = viewModel.state.value
+            if (finalState is PlayerState.Success) {
+                assertEquals(null, finalState.sleepTimerRemainingMs)
+            }
+        }
+
+    @Test
+    fun `Given CancelSleepTimer action, When no timer is active, Then no crash occurs`() =
+        runTest {
+            setupDefaultMocks()
+            val viewModel = createViewModel()
+
+            viewModel.sendAction(PlayerAction.CancelSleepTimer)
+
+            // Should not crash; verify no pause called
+            verify(exactly = 0) { playerRepository.pause() }
+        }
+
+    @Test
+    fun `Given two SetSleepTimer actions, When both expire, Then pause is called twice`() =
+        runTest {
+            setupDefaultMocks()
+            every { timeProvider.currentTimeMillis() } returnsMany listOf(
+                0L, 60_001L,       // first timer: start → expire
+                0L, 30_001L,       // second timer: start → expire
+            )
+
+            val viewModel = createViewModel()
+
+            viewModel.sendAction(PlayerAction.SetSleepTimer(60_000L))
+            viewModel.sendAction(PlayerAction.SetSleepTimer(30_000L))
+
+            verify(exactly = 2) { playerRepository.pause() }
+        }
+
+    @Test
+    fun `Given SleepTimerEndOfEpisode action with live stream, When duration is zero, Then no timer starts`() =
+        runTest {
+            setupDefaultMocks()
+            nowPlayingFlow.value = episodeTestData
+            progressFlow.value = Progress(0.seconds, 0.seconds, 0.seconds)
+
+            val viewModel = createViewModel()
+
+            viewModel.sendAction(PlayerAction.SleepTimerEndOfEpisode)
+
+            // No pause should be called for live stream (duration = 0)
+            verify(exactly = 0) { playerRepository.pause() }
+        }
 }

--- a/feature/player/src/test/kotlin/io/jacob/episodive/feature/player/PlayerViewModelTest.kt
+++ b/feature/player/src/test/kotlin/io/jacob/episodive/feature/player/PlayerViewModelTest.kt
@@ -458,33 +458,18 @@ class PlayerViewModelTest {
         }
 
     @Test
-    fun `Given SetSleepTimer action, When timer expires, Then sleepTimerRemainingMs becomes null in state`() =
+    fun `Given SetSleepTimer action, When timer expires, Then volume is restored to 1f`() =
         runTest {
-            setupPlayerRepositoryMocks()
-            val episode = episodeTestData
-            val podcast = podcastTestData
-
-            every { getNowPlayingUseCase() } returns flowOf(episode)
-            every { getPodcastUseCase(episode.feedId) } returns flowOf(podcast)
-            every { getPlaylistUseCase() } returns flowOf(listOf(episode))
-            every { getUserDataUseCase() } returns flowOf(UserData(speed = 1.0f))
+            setupDefaultMocks()
             every { timeProvider.currentTimeMillis() } returnsMany listOf(0L, 60_001L)
 
             val viewModel = createViewModel()
 
-            viewModel.state.test {
-                val state = awaitItem()
-                assertTrue(state is PlayerState.Success)
-                assertEquals(null, (state as PlayerState.Success).sleepTimerRemainingMs)
-            }
-
             viewModel.sendAction(PlayerAction.SetSleepTimer(60_000L))
 
-            // After expiry, sleepTimerRemainingMs should be null
-            val finalState = viewModel.state.value
-            if (finalState is PlayerState.Success) {
-                assertEquals(null, finalState.sleepTimerRemainingMs)
-            }
+            // finally block restores volume after expiry
+            verify { playerRepository.setVolume(0f) }  // fade to 0 at expiry
+            verify(atLeast = 1) { playerRepository.setVolume(1f) }  // restored in finally
         }
 
     @Test
@@ -500,9 +485,10 @@ class PlayerViewModelTest {
         }
 
     @Test
-    fun `Given two SetSleepTimer actions, When both expire, Then pause is called twice`() =
+    fun `Given two sequential SetSleepTimer actions, When both expire immediately, Then each triggers pause`() =
         runTest {
             setupDefaultMocks()
+            // With UnconfinedTestDispatcher, each timer expires instantly via mocked time
             every { timeProvider.currentTimeMillis() } returnsMany listOf(
                 0L, 60_001L,       // first timer: start → expire
                 0L, 30_001L,       // second timer: start → expire


### PR DESCRIPTION
## 변경 사항
- 확장 플레이어에 슬립 타이머 BottomSheet 추가 (Moon 아이콘, 속도조절-다운로드 사이 배치)
- 프리셋 시간 선택: 30초(테스트), 5/10/15/30/45/60분, 에피소드 끝까지
- 만료 15초 전부터 볼륨 페이드아웃 + 아이콘/숫자 색상 무채색 전환
- 정지 상태에서 타이머 설정 시 스낵바 경고
- setVolume API를 PlayerDataSource → PlayerRepository 체인에 추가

## 테스트
- PlayerViewModel 슬립 타이머 유닛 테스트 5개 추가
- 전체 빌드 및 기존 테스트 통과 확인