### PR TITLE
fix: 팔로우 팟캐스트 에피소드 주기 동기화 정상화

### DIFF
--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/EpisodeRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/EpisodeRepositoryImpl.kt
@@ -327,8 +327,10 @@ class EpisodeRepositoryImpl @Inject constructor(
             since = since.epochSeconds,
         )
         val episodes = responses.toEpisodes()
-        val entities = episodes.toEpisodeEntities()
-        episodeLocalDataSource.upsertEpisodes(entities)
-        return episodes
+        episodeLocalDataSource.upsertEpisodes(episodes.toEpisodeEntities())
+        // since 는 보유한 최신 에피소드의 발행 시각이며, API 의 since 경계가 inclusive 일 경우
+        // 이미 가진 에피소드가 다시 반환될 수 있다. 알림 중복 발송을 막기 위해
+        // 실제로 since 이후에 발행된 새 에피소드만 반환한다.
+        return episodes.filter { it.datePublished > since }
     }
 }

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/PodcastRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/PodcastRepositoryImpl.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import kotlin.time.Instant
 
 class PodcastRepositoryImpl @Inject constructor(
     private val podcastLocalDataSource: PodcastLocalDataSource,
@@ -200,7 +201,7 @@ class PodcastRepositoryImpl @Inject constructor(
         return podcastLocalDataSource.toggleFollowedPodcast(id)
     }
 
-    override suspend fun getFollowedPodcastIdsWithNotificationEnabled(): List<Long> {
-        return podcastLocalDataSource.getFollowedPodcastIdsWithNotificationEnabled()
+    override suspend fun getFollowedPodcastsToSync(): Map<Long, Instant> {
+        return podcastLocalDataSource.getFollowedPodcastsToSync()
     }
 }

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/repository/EpisodeRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/repository/EpisodeRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.network.datasource.ChapterRemoteDataSource
 import io.jacob.episodive.core.network.datasource.EpisodeRemoteDataSource
 import io.jacob.episodive.core.network.datasource.SoundbiteRemoteDataSource
+import io.jacob.episodive.core.network.mapper.toEpisodeResponses
 import io.jacob.episodive.core.testing.model.episodeTestData
 import io.jacob.episodive.core.testing.util.MainDispatcherRule
 import io.mockk.coEvery
@@ -77,6 +78,28 @@ class EpisodeRepositoryImplTest {
             assertEquals(emptyList<Any>(), result)
             coVerify { episodeRemoteDataSource.getEpisodesByFeedId(feedId = feedId, since = since.epochSeconds) }
             coVerify { episodeLocalDataSource.upsertEpisodes(emptyList()) }
+        }
+
+    @Test
+    fun `Given boundary and newer episodes, When fetchAndSaveNewEpisodes, Then returns only episodes after since`() =
+        runTest {
+            // Given
+            val feedId = 5778530L
+            val since = Instant.fromEpochSeconds(1000)
+            val boundaryEpisode = episodeTestData.copy(id = 1L, datePublished = since)
+            val newerEpisode = episodeTestData.copy(id = 2L, datePublished = Instant.fromEpochSeconds(2000))
+            coEvery {
+                episodeRemoteDataSource.getEpisodesByFeedId(feedId = feedId, since = since.epochSeconds)
+            } returns listOf(boundaryEpisode, newerEpisode).toEpisodeResponses()
+
+            // When
+            val result = repository.fetchAndSaveNewEpisodes(feedId, since)
+
+            // Then: 이미 보유한 경계 에피소드는 제외하고 since 이후 새 에피소드만 반환
+            assertEquals(1, result.size)
+            assertEquals(2L, result[0].id)
+            // DB 캐시에는 응답 전체를 저장한다
+            coVerify { episodeLocalDataSource.upsertEpisodes(any()) }
         }
 
     @Test

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/repository/PodcastRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/repository/PodcastRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import kotlin.time.Instant
 
 class PodcastRepositoryImplTest {
     @get:Rule
@@ -40,18 +41,22 @@ class PodcastRepositoryImplTest {
     )
 
     @Test
-    fun `When getFollowedPodcastIdsWithNotificationEnabled, Then delegates to localDataSource`() =
+    fun `When getFollowedPodcastsToSync, Then delegates to localDataSource`() =
         runTest {
             // Given
-            val expected = listOf(1L, 2L, 3L)
-            coEvery { podcastLocalDataSource.getFollowedPodcastIdsWithNotificationEnabled() } returns expected
+            val expected = mapOf(
+                1L to Instant.fromEpochSeconds(1000),
+                2L to Instant.fromEpochSeconds(2000),
+                3L to Instant.fromEpochSeconds(3000),
+            )
+            coEvery { podcastLocalDataSource.getFollowedPodcastsToSync() } returns expected
 
             // When
-            val result = repository.getFollowedPodcastIdsWithNotificationEnabled()
+            val result = repository.getFollowedPodcastsToSync()
 
             // Then
             assertEquals(expected, result)
-            coVerify { podcastLocalDataSource.getFollowedPodcastIdsWithNotificationEnabled() }
+            coVerify { podcastLocalDataSource.getFollowedPodcastsToSync() }
         }
 
     @Test

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/dao/PodcastDao.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/dao/PodcastDao.kt
@@ -3,6 +3,7 @@ package io.jacob.episodive.core.database.dao
 import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.MapColumn
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
@@ -246,6 +247,6 @@ interface PodcastDao {
     )
     fun getFollowedPodcastsPaging(query: String? = null): PagingSource<Int, PodcastWithExtrasView>
 
-    @Query("SELECT id FROM followed_podcasts WHERE isNotificationEnabled = 1")
-    suspend fun getFollowedPodcastIdsWithNotificationEnabled(): List<Long>
+    @Query("SELECT id, followedAt FROM followed_podcasts")
+    suspend fun getFollowedPodcastsToSync(): Map<@MapColumn(columnName = "id") Long, @MapColumn(columnName = "followedAt") Instant>
 }

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/datasource/PodcastLocalDataSource.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/datasource/PodcastLocalDataSource.kt
@@ -24,5 +24,5 @@ interface PodcastLocalDataSource {
     suspend fun toggleFollowedPodcast(id: Long): Boolean
     fun getFollowedPodcasts(query: String? = null, limit: Int): Flow<List<PodcastWithExtrasView>>
     fun getFollowedPodcastsPaging(query: String? = null): PagingSource<Int, PodcastWithExtrasView>
-    suspend fun getFollowedPodcastIdsWithNotificationEnabled(): List<Long>
+    suspend fun getFollowedPodcastsToSync(): Map<Long, Instant>
 }

--- a/core/database/src/main/kotlin/io/jacob/episodive/core/database/datasource/PodcastLocalDataSourceImpl.kt
+++ b/core/database/src/main/kotlin/io/jacob/episodive/core/database/datasource/PodcastLocalDataSourceImpl.kt
@@ -97,7 +97,7 @@ class PodcastLocalDataSourceImpl(
         )
     }
 
-    override suspend fun getFollowedPodcastIdsWithNotificationEnabled(): List<Long> {
-        return podcastDao.getFollowedPodcastIdsWithNotificationEnabled()
+    override suspend fun getFollowedPodcastsToSync(): Map<Long, Instant> {
+        return podcastDao.getFollowedPodcastsToSync()
     }
 }

--- a/core/database/src/test/kotlin/io/jacob/episodive/core/database/dao/PodcastDaoTest.kt
+++ b/core/database/src/test/kotlin/io/jacob/episodive/core/database/dao/PodcastDaoTest.kt
@@ -1019,7 +1019,7 @@ class PodcastDaoTest {
         }
 
     @Test
-    fun `Given followed podcasts with notification enabled, When getFollowedPodcastIdsWithNotificationEnabled, Then returns only enabled ids`() =
+    fun `Given followed podcasts, When getFollowedPodcastsToSync, Then returns all ids with followedAt`() =
         runTest {
             // Given
             dao.upsertPodcast(podcastEntity.copy(id = 1L))
@@ -1036,16 +1036,23 @@ class PodcastDaoTest {
             )
 
             // When
-            val result = dao.getFollowedPodcastIdsWithNotificationEnabled()
+            val result = dao.getFollowedPodcastsToSync()
 
             // Then
-            assertEquals(listOf(1L, 3L), result.sorted())
+            assertEquals(
+                mapOf(
+                    1L to Instant.fromEpochSeconds(1000),
+                    2L to Instant.fromEpochSeconds(2000),
+                    3L to Instant.fromEpochSeconds(3000),
+                ),
+                result,
+            )
         }
 
     @Test
-    fun `Given no followed podcasts, When getFollowedPodcastIdsWithNotificationEnabled, Then returns empty list`() =
+    fun `Given no followed podcasts, When getFollowedPodcastsToSync, Then returns empty map`() =
         runTest {
-            val result = dao.getFollowedPodcastIdsWithNotificationEnabled()
+            val result = dao.getFollowedPodcastsToSync()
             assertTrue(result.isEmpty())
         }
 

--- a/core/database/src/test/kotlin/io/jacob/episodive/core/database/datasource/PodcastLocalDataSourceTest.kt
+++ b/core/database/src/test/kotlin/io/jacob/episodive/core/database/datasource/PodcastLocalDataSourceTest.kt
@@ -324,14 +324,14 @@ class PodcastLocalDataSourceTest {
     }
 
     @Test
-    fun `When getFollowedPodcastIdsWithNotificationEnabled is called, Then dao is called`() =
+    fun `When getFollowedPodcastsToSync is called, Then dao is called`() =
         runTest {
             // When
-            dataSource.getFollowedPodcastIdsWithNotificationEnabled()
+            dataSource.getFollowedPodcastsToSync()
 
             // Then
             coVerify {
-                dao.getFollowedPodcastIdsWithNotificationEnabled()
+                dao.getFollowedPodcastsToSync()
             }
         }
 }

--- a/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/repository/PodcastRepository.kt
+++ b/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/repository/PodcastRepository.kt
@@ -5,6 +5,7 @@ import io.jacob.episodive.core.model.Category
 import io.jacob.episodive.core.model.Channel
 import io.jacob.episodive.core.model.Podcast
 import kotlinx.coroutines.flow.Flow
+import kotlin.time.Instant
 
 interface PodcastRepository {
     fun searchPodcasts(
@@ -66,5 +67,5 @@ interface PodcastRepository {
 
     suspend fun toggleFollowed(id: Long): Boolean
 
-    suspend fun getFollowedPodcastIdsWithNotificationEnabled(): List<Long>
+    suspend fun getFollowedPodcastsToSync(): Map<Long, Instant>
 }

--- a/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/usecase/episode/SyncNewEpisodesUseCase.kt
+++ b/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/usecase/episode/SyncNewEpisodesUseCase.kt
@@ -10,11 +10,10 @@ class SyncNewEpisodesUseCase @Inject constructor(
     private val episodeRepository: EpisodeRepository,
 ) {
     suspend operator fun invoke(): List<NewEpisodeResult> {
-        val feedIds = podcastRepository.getFollowedPodcastIdsWithNotificationEnabled()
-        return feedIds.mapNotNull { feedId ->
+        val syncTargets = podcastRepository.getFollowedPodcastsToSync()
+        return syncTargets.mapNotNull { (feedId, followedAt) ->
             try {
-                val since = episodeRepository.getLatestEpisodeDatePublished(feedId)
-                    ?: return@mapNotNull null
+                val since = episodeRepository.getLatestEpisodeDatePublished(feedId) ?: followedAt
                 val newEpisodes = episodeRepository.fetchAndSaveNewEpisodes(feedId, since)
                 if (newEpisodes.isNotEmpty()) NewEpisodeResult(feedId, newEpisodes) else null
             } catch (_: Exception) {

--- a/core/domain/src/test/kotlin/io/jacob/episodive/core/domain/usecase/episode/SyncNewEpisodesUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/io/jacob/episodive/core/domain/usecase/episode/SyncNewEpisodesUseCaseTest.kt
@@ -28,7 +28,7 @@ class SyncNewEpisodesUseCaseTest {
 
     @Test
     fun `Given no followed podcasts, when invoke, then returns empty list`() = runTest {
-        coEvery { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() } returns emptyList()
+        coEvery { podcastRepository.getFollowedPodcastsToSync() } returns emptyMap()
 
         val result = useCase()
 
@@ -36,12 +36,13 @@ class SyncNewEpisodesUseCaseTest {
     }
 
     @Test
-    fun `Given followed podcasts with new episodes, when invoke, then returns results`() = runTest {
+    fun `Given followed podcast with cached episodes, when invoke, then syncs since latest cached date`() = runTest {
         val feedId = 5778530L
+        val followedAt = Instant.fromEpochSeconds(1757700000)
         val since = Instant.fromEpochSeconds(1757797200)
         val newEpisodes = episodeTestDataList.take(2)
 
-        coEvery { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() } returns listOf(feedId)
+        coEvery { podcastRepository.getFollowedPodcastsToSync() } returns mapOf(feedId to followedAt)
         coEvery { episodeRepository.getLatestEpisodeDatePublished(feedId) } returns since
         coEvery { episodeRepository.fetchAndSaveNewEpisodes(feedId, since) } returns newEpisodes
 
@@ -50,27 +51,33 @@ class SyncNewEpisodesUseCaseTest {
         assertEquals(1, result.size)
         assertEquals(feedId, result[0].feedId)
         assertEquals(2, result[0].episodes.size)
+        coVerify(exactly = 1) { episodeRepository.fetchAndSaveNewEpisodes(feedId, since) }
     }
 
     @Test
-    fun `Given followed podcast with no cached episodes, when invoke, then skips it`() = runTest {
+    fun `Given followed podcast with no cached episodes, when invoke, then falls back to followedAt`() = runTest {
         val feedId = 5778530L
+        val followedAt = Instant.fromEpochSeconds(1757700000)
+        val newEpisodes = episodeTestDataList.take(2)
 
-        coEvery { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() } returns listOf(feedId)
+        coEvery { podcastRepository.getFollowedPodcastsToSync() } returns mapOf(feedId to followedAt)
         coEvery { episodeRepository.getLatestEpisodeDatePublished(feedId) } returns null
+        coEvery { episodeRepository.fetchAndSaveNewEpisodes(feedId, followedAt) } returns newEpisodes
 
         val result = useCase()
 
-        assertTrue(result.isEmpty())
-        coVerify(exactly = 0) { episodeRepository.fetchAndSaveNewEpisodes(any(), any()) }
+        assertEquals(1, result.size)
+        assertEquals(feedId, result[0].feedId)
+        coVerify(exactly = 1) { episodeRepository.fetchAndSaveNewEpisodes(feedId, followedAt) }
     }
 
     @Test
     fun `Given followed podcast with no new episodes, when invoke, then returns empty`() = runTest {
         val feedId = 5778530L
+        val followedAt = Instant.fromEpochSeconds(1757700000)
         val since = Instant.fromEpochSeconds(1757797200)
 
-        coEvery { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() } returns listOf(feedId)
+        coEvery { podcastRepository.getFollowedPodcastsToSync() } returns mapOf(feedId to followedAt)
         coEvery { episodeRepository.getLatestEpisodeDatePublished(feedId) } returns since
         coEvery { episodeRepository.fetchAndSaveNewEpisodes(feedId, since) } returns emptyList()
 
@@ -83,11 +90,14 @@ class SyncNewEpisodesUseCaseTest {
     fun `Given network error for one feed, when invoke, then continues with others`() = runTest {
         val feedId1 = 5778530L
         val feedId2 = 9999999L
+        val followedAt1 = Instant.fromEpochSeconds(1757600000)
+        val followedAt2 = Instant.fromEpochSeconds(1757650000)
         val since1 = Instant.fromEpochSeconds(1757797200)
         val since2 = Instant.fromEpochSeconds(1757883600)
         val newEpisodes = episodeTestDataList.take(1)
 
-        coEvery { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() } returns listOf(feedId1, feedId2)
+        coEvery { podcastRepository.getFollowedPodcastsToSync() } returns
+            mapOf(feedId1 to followedAt1, feedId2 to followedAt2)
         coEvery { episodeRepository.getLatestEpisodeDatePublished(feedId1) } returns since1
         coEvery { episodeRepository.fetchAndSaveNewEpisodes(feedId1, since1) } throws RuntimeException("Network error")
         coEvery { episodeRepository.getLatestEpisodeDatePublished(feedId2) } returns since2
@@ -100,13 +110,15 @@ class SyncNewEpisodesUseCaseTest {
     }
 
     @Test
-    fun `Given multiple followed podcasts, when invoke, then syncs only notification-enabled ones`() = runTest {
+    fun `Given multiple followed podcasts, when invoke, then syncs all of them`() = runTest {
         val feedId1 = 5778530L
         val feedId2 = 9999999L
+        val followedAt = Instant.fromEpochSeconds(1757600000)
         val since = Instant.fromEpochSeconds(1757797200)
         val newEpisodes = episodeTestDataList.take(1)
 
-        coEvery { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() } returns listOf(feedId1, feedId2)
+        coEvery { podcastRepository.getFollowedPodcastsToSync() } returns
+            mapOf(feedId1 to followedAt, feedId2 to followedAt)
         coEvery { episodeRepository.getLatestEpisodeDatePublished(any()) } returns since
         coEvery { episodeRepository.fetchAndSaveNewEpisodes(feedId1, since) } returns newEpisodes
         coEvery { episodeRepository.fetchAndSaveNewEpisodes(feedId2, since) } returns newEpisodes
@@ -114,6 +126,6 @@ class SyncNewEpisodesUseCaseTest {
         val result = useCase()
 
         assertEquals(2, result.size)
-        coVerify(exactly = 1) { podcastRepository.getFollowedPodcastIdsWithNotificationEnabled() }
+        coVerify(exactly = 1) { podcastRepository.getFollowedPodcastsToSync() }
     }
 }


### PR DESCRIPTION
## 변경 사항
- WorkManager 주기 동기화(`SyncNewEpisodesUseCase`)가 항상 빈 결과를 반환하던 문제 수정
  - 동기화 대상을 `isNotificationEnabled = 1` 조건이 아닌 **전체 팔로우 팟캐스트**로 변경
  - 해당 플래그를 활성화하는 경로(UI/코드)가 없어 동기화가 사실상 동작하지 않았음
  - `getFollowedPodcastsToSync(): Map<Long, Instant>` 로 교체 (Room `@MapColumn`, 마이그레이션 불필요)
- 캐시된 에피소드가 없는 팟캐스트(예: 온보딩에서 팔로우만 한 경우)는 `followedAt` 을 기준 시각으로 사용
  - 기존에는 `getLatestEpisodeDatePublished` 가 null이면 영구히 건너뛰었음
- `fetchAndSaveNewEpisodes` 가 실제 신규 에피소드(`datePublished > since`)만 반환하도록 필터링
  - API `since` 경계가 inclusive일 때 옛 에피소드로 알림이 반복 발송되는 것 방지
  - DB 캐시에는 응답 전체를 저장

## 테스트
- `core:database` / `core:data` / `core:domain` 전체 유닛 테스트 통과
- 신규/갱신 테스트
  - `PodcastDaoTest`: `getFollowedPodcastsToSync` Map 반환 (실제 Room 검증)
  - `SyncNewEpisodesUseCaseTest`: 캐시 없을 때 followedAt fallback 케이스
  - `EpisodeRepositoryImplTest`: since 경계 신규 에피소드 필터링 케이스
- 에뮬레이터 실동작 확인 (15분 주기로 임시 변경 후 JobScheduler 등록 검증, 이후 원복)