### PR TITLE
fix: 다운로드한 에피소드 오프라인 재생 지원

### DIFF
--- a/core/player/build.gradle.kts
+++ b/core/player/build.gradle.kts
@@ -12,6 +12,7 @@ android {
 dependencies {
     implementation(projects.core.common)
     implementation(projects.core.model)
+    implementation(projects.core.domain)
 
     //----- Media3 Exoplayer
     implementation(libs.androidx.media3.exoplayer)

--- a/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
+++ b/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.Timeline
 import androidx.media3.common.Tracks
 import androidx.media3.common.text.CueGroup
 import androidx.media3.exoplayer.ExoPlayer
+import io.jacob.episodive.core.domain.download.EpisodeDownloader
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Progress
 import io.jacob.episodive.core.model.mapper.toDurationMillis
@@ -32,6 +33,7 @@ import kotlin.time.Duration
 
 class PlayerDataSourceImpl @Inject constructor(
     private val player: ExoPlayer,
+    private val episodeDownloader: EpisodeDownloader,
 ) : PlayerDataSource {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -170,8 +172,11 @@ class PlayerDataSourceImpl @Inject constructor(
             .setArtworkUri(image.ifEmpty { feedImage }.toUri())
             .build()
 
-        val uri = if (isDownloaded && filePath != null) {
-            android.net.Uri.fromFile(java.io.File(filePath))
+        // 다운로드 완료 판정은 DB 상태가 아니라 실제 파일 존재로 한다.
+        // filePath는 상대경로("feedId/id.ext")이므로 다운로드 디렉토리 기준 절대경로로 변환한다.
+        val localPath = filePath
+        val uri = if (localPath != null && episodeDownloader.isFileDownloaded(localPath)) {
+            android.net.Uri.fromFile(java.io.File(episodeDownloader.getDownloadDirectory(), localPath))
         } else {
             enclosureUrl.toUri()
         }

--- a/core/player/src/main/kotlin/io/jacob/episodive/core/player/di/DataSourceModule.kt
+++ b/core/player/src/main/kotlin/io/jacob/episodive/core/player/di/DataSourceModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.jacob.episodive.core.common.EpisodivePlayers
 import io.jacob.episodive.core.common.Player
+import io.jacob.episodive.core.domain.download.EpisodeDownloader
 import io.jacob.episodive.core.player.datasource.PlayerDataSource
 import io.jacob.episodive.core.player.datasource.PlayerDataSourceImpl
 import javax.inject.Singleton
@@ -19,9 +20,11 @@ object DataSourceModule {
     @Player(EpisodivePlayers.Main)
     fun provideMainPlayerDataSource(
         @Player(EpisodivePlayers.Main) exoPlayer: ExoPlayer,
+        episodeDownloader: EpisodeDownloader,
     ): PlayerDataSource {
         return PlayerDataSourceImpl(
             player = exoPlayer,
+            episodeDownloader = episodeDownloader,
         )
     }
 
@@ -30,9 +33,11 @@ object DataSourceModule {
     @Player(EpisodivePlayers.Clip)
     fun provideClipPlayerDataSource(
         @Player(EpisodivePlayers.Clip) exoPlayer: ExoPlayer,
+        episodeDownloader: EpisodeDownloader,
     ): PlayerDataSource {
         return PlayerDataSourceImpl(
             player = exoPlayer,
+            episodeDownloader = episodeDownloader,
         )
     }
 }


### PR DESCRIPTION
## 변경 사항
- 다운로드 완료된 에피소드도 항상 스트리밍 URL로 재생되던 **기존 버그** 수정(오프라인 재생 미작동)
- `toMediaItem`이 DB `downloadStatus`(==COMPLETED) 대신 **실제 파일 존재(`isFileDownloaded`)** 로 로컬/스트리밍 분기
- 상대경로 `filePath`("feedId/id.ext")를 다운로드 디렉토리 기준 **절대경로**로 변환
- `core/player` → `core/domain` 의존 추가, `PlayerDataSourceImpl`에 `EpisodeDownloader` 주입(`DataSourceModule` provider 2곳 갱신)

## 테스트
- `core:player` / `feature:player` 유닛 테스트 통과, 전체 빌드(Hilt 그래프) 성공
- **에뮬레이터 오프라인 검증**: 에어플레인 모드(네트워크 차단)에서 다운로드된 에피소드 재생 → `state=PLAYING`, position 진행(3.6s→6.7s, buffered 60s), 오디오 `PlaybackException` 없음(네트워크 실패는 아트워크 이미지뿐) → **로컬 파일 재생 확정**

## 참고
- #77(다운로드 상태 표시 재설계)에서 분리된 후속 작업. `isFileDownloaded`/`getDownloadDirectory`는 #77에서 도입된 API 사용.
