### PR TITLE
fix: 온보딩 채널 팔로우 토글 시 리스트 리로드·스크롤 튐 제거

### DIFF
--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/PodcastRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/PodcastRepositoryImpl.kt
@@ -166,7 +166,6 @@ class PodcastRepositoryImpl @Inject constructor(
             ),
             pagingSourceFactory = {
                 RecommendedPodcastPagingSource(
-                    database = podcastLocalDataSource.database,
                     podcastLocal = podcastLocalDataSource,
                     podcastRemote = podcastRemoteDataSource,
                     feedLocal = feedLocalDataSource,

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/paging/RecommendedPodcastPagingSource.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/paging/RecommendedPodcastPagingSource.kt
@@ -2,8 +2,6 @@ package io.jacob.episodive.core.data.util.paging
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import androidx.room.InvalidationTracker
-import androidx.room.RoomDatabase
 import io.jacob.episodive.core.database.datasource.FeedLocalDataSource
 import io.jacob.episodive.core.database.datasource.PodcastLocalDataSource
 import io.jacob.episodive.core.database.mapper.toFeedEntities
@@ -31,7 +29,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 class RecommendedPodcastPagingSource(
-    private val database: RoomDatabase,
     private val podcastLocal: PodcastLocalDataSource,
     private val podcastRemote: PodcastRemoteDataSource,
     private val feedLocal: FeedLocalDataSource,
@@ -41,19 +38,6 @@ class RecommendedPodcastPagingSource(
     private val categories: List<Category> = emptyList(),
     private val timeToLive: Duration = 10.minutes,
 ) : PagingSource<Int, PodcastWithExtrasView>() {
-
-    private val observer = object : InvalidationTracker.Observer(arrayOf("followed_podcasts")) {
-        override fun onInvalidated(tables: Set<String>) {
-            invalidate()
-        }
-    }
-
-    init {
-        database.invalidationTracker.addObserver(observer)
-        registerInvalidatedCallback {
-            database.invalidationTracker.removeObserver(observer)
-        }
-    }
 
     override fun getRefreshKey(state: PagingState<Int, PodcastWithExtrasView>): Int? {
         return state.anchorPosition?.let { anchorPosition ->

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/paging/RecommendedPodcastPagingSourceTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/paging/RecommendedPodcastPagingSourceTest.kt
@@ -1,8 +1,6 @@
 package io.jacob.episodive.core.data.util.paging
 
 import androidx.paging.PagingSource
-import androidx.room.InvalidationTracker
-import androidx.room.RoomDatabase
 import io.jacob.episodive.core.database.datasource.FeedLocalDataSource
 import io.jacob.episodive.core.database.datasource.PodcastLocalDataSource
 import io.jacob.episodive.core.database.model.FeedEntity
@@ -33,10 +31,6 @@ class RecommendedPodcastPagingSourceTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    private val invalidationTracker = mockk<InvalidationTracker>(relaxed = true)
-    private val database = mockk<RoomDatabase>(relaxed = true) {
-        every { invalidationTracker } returns this@RecommendedPodcastPagingSourceTest.invalidationTracker
-    }
     private val podcastLocal = mockk<PodcastLocalDataSource>(relaxed = true)
     private val podcastRemote = mockk<PodcastRemoteDataSource>(relaxed = true)
     private val feedLocal = mockk<FeedLocalDataSource>(relaxed = true)
@@ -49,7 +43,6 @@ class RecommendedPodcastPagingSourceTest {
         categories: List<Category> = emptyList(),
         timeToLive: Duration = 10.minutes,
     ) = RecommendedPodcastPagingSource(
-        database = database,
         podcastLocal = podcastLocal,
         podcastRemote = podcastRemote,
         feedLocal = feedLocal,

--- a/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Podcast.kt
+++ b/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Podcast.kt
@@ -175,6 +175,7 @@ private fun rememberPodcastTextSectionMinHeight(): Dp {
 fun PodcastDetailItem(
     modifier: Modifier = Modifier,
     podcast: Podcast,
+    isFollowed: Boolean = podcast.isFollowed,
     onClick: () -> Unit = {},
     onToggleFollowed: () -> Unit = {},
 ) {
@@ -216,7 +217,7 @@ fun PodcastDetailItem(
                     modifier = Modifier
                         .size(34.dp),
                     shape = MaterialTheme.shapes.medium,
-                    checked = podcast.isFollowed,
+                    checked = isFollowed,
                     onCheckedChange = { onToggleFollowed() },
                     icon = {
                         Icon(

--- a/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingScreen.kt
@@ -78,6 +78,7 @@ fun OnboardingRoute(
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val followedPodcastIds by viewModel.followedPodcastIds.collectAsStateWithLifecycle()
     val pagerState = rememberPagerState(pageCount = { OnboardingPage.count })
 
     val moreCategories = stringResource(R.string.feature_onboarding_category_more_categories)
@@ -99,6 +100,7 @@ fun OnboardingRoute(
             pagerState = pagerState,
             categories = s.categories,
             podcasts = viewModel.recommendedPodcasts,
+            followedPodcastIds = followedPodcastIds,
             onChooseCategory = { viewModel.sendAction(OnboardingAction.ChooseCategory(it)) },
             onChoosePodcast = { viewModel.sendAction(OnboardingAction.ChoosePodcast(it)) },
             onNextPage = { viewModel.sendAction(OnboardingAction.NextPage) },
@@ -114,6 +116,7 @@ internal fun OnboardingScreen(
     pagerState: PagerState,
     categories: List<SelectableCategory>,
     podcasts: Flow<PagingData<Podcast>>,
+    followedPodcastIds: Set<Long> = emptySet(),
     onChooseCategory: (Category) -> Unit,
     onChoosePodcast: (Podcast) -> Unit,
     onNextPage: () -> Unit,
@@ -142,6 +145,7 @@ internal fun OnboardingScreen(
                     PodcastSelectionScreen(
                         modifier = modifier,
                         podcasts = podcasts,
+                        followedPodcastIds = followedPodcastIds,
                         onToggleFollowedPodcast = onChoosePodcast,
                     )
 
@@ -315,6 +319,7 @@ private fun CategorySelectionScreen(
 private fun PodcastSelectionScreen(
     modifier: Modifier = Modifier,
     podcasts: Flow<PagingData<Podcast>>,
+    followedPodcastIds: Set<Long> = emptySet(),
     onToggleFollowedPodcast: (Podcast) -> Unit,
 ) {
     val podcastsPaging = podcasts.collectAsLazyPagingItems()
@@ -372,9 +377,10 @@ private fun PodcastSelectionScreen(
                 key = { podcastsPaging.peek(it)?.id ?: it },
             ) { index ->
                 val podcast = podcastsPaging[index] ?: return@items
-
+                // PagingData 는 팔로우 상태를 무효화하지 않으므로 followedPodcastIds 로 오버레이한다.
                 PodcastDetailItem(
                     podcast = podcast,
+                    isFollowed = podcast.id in followedPodcastIds,
                     onClick = { onToggleFollowedPodcast(podcast) },
                     onToggleFollowed = { onToggleFollowedPodcast(podcast) },
                 )

--- a/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.jacob.episodive.core.domain.usecase.podcast.GetFollowedPodcastsUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetUserRecommendedPodcastsPagingUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.ToggleFollowedUseCase
 import io.jacob.episodive.core.domain.usecase.user.GetPreferredCategoriesUseCase
@@ -37,6 +38,7 @@ class OnboardingViewModel @Inject constructor(
     private val toggleCategoryUseCase: ToggleCategoryUseCase,
     private val toggleFollowedUseCase: ToggleFollowedUseCase,
     private val getPreferredCategoriesUseCase: GetPreferredCategoriesUseCase,
+    getFollowedPodcastsUseCase: GetFollowedPodcastsUseCase,
     getUserRecommendedPodcastsPagingUseCase: GetUserRecommendedPodcastsPagingUseCase,
 ) : ViewModel() {
 
@@ -59,6 +61,17 @@ class OnboardingViewModel @Inject constructor(
                 flowOf(PagingData.empty())
             }
         }.cachedIn(viewModelScope)
+
+    // 팔로우 상태는 PagingData 를 무효화하지 않고 로컬 오버레이로만 반영한다.
+    // (팔로우 토글이 리스트 전체를 refresh 시켜 스크롤이 튀는 문제 방지)
+    val followedPodcastIds: StateFlow<Set<Long>> =
+        getFollowedPodcastsUseCase(max = Int.MAX_VALUE)
+            .map { podcasts -> podcasts.map { it.id }.toSet() }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = emptySet(),
+            )
 
     val state: StateFlow<OnboardingState> = _categories.map { categories ->
         OnboardingState.Success(

--- a/feature/onboarding/src/test/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModelTest.kt
@@ -2,6 +2,7 @@ package io.jacob.episodive.feature.onboarding
 
 import androidx.paging.PagingData
 import app.cash.turbine.test
+import io.jacob.episodive.core.domain.usecase.podcast.GetFollowedPodcastsUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetUserRecommendedPodcastsPagingUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.ToggleFollowedUseCase
 import io.jacob.episodive.core.domain.usecase.user.GetPreferredCategoriesUseCase
@@ -35,6 +36,7 @@ class OnboardingViewModelTest {
     private val toggleCategoryUseCase = mockk<ToggleCategoryUseCase>(relaxed = true)
     private val toggleFollowedUseCase = mockk<ToggleFollowedUseCase>(relaxed = true)
     private val getPreferredCategoriesUseCase = mockk<GetPreferredCategoriesUseCase>(relaxed = true)
+    private val getFollowedPodcastsUseCase = mockk<GetFollowedPodcastsUseCase>(relaxed = true)
     private val getUserRecommendedPodcastsPagingUseCase =
         mockk<GetUserRecommendedPodcastsPagingUseCase>(relaxed = true)
 
@@ -44,6 +46,7 @@ class OnboardingViewModelTest {
             toggleCategoryUseCase = toggleCategoryUseCase,
             toggleFollowedUseCase = toggleFollowedUseCase,
             getPreferredCategoriesUseCase = getPreferredCategoriesUseCase,
+            getFollowedPodcastsUseCase = getFollowedPodcastsUseCase,
             getUserRecommendedPodcastsPagingUseCase = getUserRecommendedPodcastsPagingUseCase,
         )
     }


### PR DESCRIPTION
## 변경 사항
온보딩 채널(팟캐스트) 선택 화면에서 팔로우 버튼을 누를 때마다 리스트가 처음부터 다시 로드되어 스크롤 위치가 튀고 순서가 뒤틀리던 문제를 수정합니다. 특히 리스트를 아래로 쭉 내린 뒤 팔로우를 누르면 아이템이 다른 위치로 점프하는 증상으로 재현됐습니다.

**원인**: `RecommendedPodcastPagingSource`가 `followed_podcasts` 테이블을 Room `InvalidationTracker`로 관찰하며 변경 시 `invalidate()`를 호출했습니다. `PodcastWithExtrasView`가 해당 테이블을 `LEFT JOIN`하므로, 팔로우 토글 → 테이블 변경 → PagingSource 무효화 → Paging 전체 REFRESH → 리스트 리로드로 이어졌습니다.

- `RecommendedPodcastPagingSource`의 `followed_podcasts` invalidation observer 제거 (불필요해진 `database` 파라미터도 함께 제거)
- `OnboardingViewModel`에 `GetFollowedPodcastsUseCase` 기반 `followedPodcastIds` `StateFlow` 추가 (Room Flow라 토글 시 자동 갱신)
- `OnboardingScreen`이 PagingData의 `isFollowed` 대신 `followedPodcastIds`로 팔로우 표시를 오버레이 → 리스트는 안정적으로 유지, 체크 상태만 실시간 반영
- `PodcastDetailItem`에 기본값(`podcast.isFollowed`) 있는 `isFollowed` 파라미터 추가 (기존 호출부 영향 없음)

## 테스트
- `:core:data`, `:feature:onboarding` 유닛 테스트 통과
- 에뮬레이터 재현 검증: 앱 초기화 → 카테고리 10개 선택 → 채널 화면에서 **스크롤 하단까지 내린 뒤 팔로우 토글** 시
  - 스크롤 위치·항목 순서 그대로 유지, 팔로우 체크만 즉시 반영
  - logcat상 `load()` 호출이 `offset 0→10→20→30` 단조 증가만, refresh(`offset:0`) 재발생 0회