### PR TITLE
chore: .claude/settings.json을 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ local.properties
 .kotlin
 *.hprof
 .claude/settings.local.json
+# graphify PreToolUse 가드(머신 종속 절대경로) — graphify claude install로 개발자별 재생성
+.claude/settings.json
 .claude/worktrees/
 .omc/


### PR DESCRIPTION
## 변경 사항

- `.gitignore`에 `.claude/settings.json` 추가

`graphify claude install`이 생성하는 `.claude/settings.json`은 PreToolUse 그래프-우선 가드를 담지만, graphify 바이너리의 **머신 종속 절대경로**(`/Users/.../graphify hook-guard`)를 포함하고 graphify 설치를 전제한다. git hook과 동일하게 **개발자별 로컬 셋업**이므로 버전 관리에서 제외한다(clone 후 `graphify claude install`로 각자 재생성). 팀 전체 graphify-우선 지침은 이미 커밋된 `CLAUDE.md`(`## graphify` · `## Codebase Analysis Policy`)가 제공하므로 손실 없음.

## 테스트

- `git check-ignore` 로 `.claude/settings.json`이 무시됨을 확인(untracked 노이즈 제거).
- `.gitignore`만 변경. `GRAPHIFY_SKIP_HOOK=1`로 커밋해 그래프(graph.json 4250 노드) 미변경 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDZ5V4pRoQqest4PzK2MTu
