### PR TITLE
fix: 데이터 없는 홈 섹션 숨기기

### DIFF
--- a/core/testing/src/main/kotlin/io/jacob/episodive/core/testing/model/ChannelTestData.kt
+++ b/core/testing/src/main/kotlin/io/jacob/episodive/core/testing/model/ChannelTestData.kt
@@ -25,4 +25,13 @@ val channelTestData = Channel(
     )
 )
 
-val channelTestDataList = List(10) { channelTestData }
+/**
+ * 같은 객체를 10번 담으면 id 가 전부 1 이라 LazyRow 의 `key = { it.id }` 가
+ * "Key 1 was already used" 로 터진다. 실제 채널 id 는 유일하므로 여기서도 나눠 준다.
+ */
+val channelTestDataList = List(10) { index ->
+    channelTestData.copy(
+        id = index + 1L,
+        title = "${channelTestData.title} ${index + 1}",
+    )
+}

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -225,7 +224,23 @@ internal fun HomeScreen(
                         // 상단 가장자리는 시트 드래그(collapse)가 피드백을 대신한다.
                         overscrollEffect = null,
                     ) {
-                        itemWithDivider {
+                        // 응답이 비어 온 섹션은 제목만 덩그러니 남으므로 통째로 건너뛴다.
+                        // 구분선은 섹션 뒤가 아니라 앞에 붙인다 — 그래야 앞 섹션이 비어도
+                        // 선이 겹치지 않고, 마지막 섹션 뒤에 선이 남지도 않는다.
+                        var sectionRendered = false
+                        fun section(
+                            items: Collection<*>,
+                            content: @Composable LazyItemScope.() -> Unit,
+                        ) {
+                            if (items.isEmpty()) return
+                            if (sectionRendered) {
+                                item { HorizontalDivider(modifier = Modifier.padding(16.dp)) }
+                            }
+                            sectionRendered = true
+                            item(content = content)
+                        }
+
+                        section(userRecentPodcasts) {
                             PodcastsSection(
                                 title = stringResource(R.string.feature_home_section_my_recent_feeds),
                                 podcasts = userRecentPodcasts,
@@ -236,7 +251,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        itemWithDivider {
+                        section(randomEpisodes) {
                             EpisodesSection(
                                 title = stringResource(R.string.feature_home_section_random_episodes),
                                 episodes = randomEpisodes,
@@ -246,7 +261,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        itemWithDivider {
+                        section(userTrendingPodcasts) {
                             PodcastsSection(
                                 title = stringResource(R.string.feature_home_section_my_trending_feeds),
                                 podcasts = userTrendingPodcasts,
@@ -257,7 +272,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        itemWithDivider {
+                        section(followedPodcasts) {
                             PodcastsSection(
                                 title = stringResource(R.string.feature_home_section_followed_podcasts),
                                 podcasts = followedPodcasts,
@@ -270,7 +285,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        itemWithDivider {
+                        section(localTrendingPodcasts) {
                             PodcastsSection(
                                 title = stringResource(R.string.feature_home_section_trending_in_local),
                                 podcasts = localTrendingPodcasts,
@@ -281,7 +296,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        itemWithDivider {
+                        section(foreignTrendingPodcasts) {
                             PodcastsSection(
                                 title = stringResource(R.string.feature_home_section_trending_in_foreign),
                                 podcasts = foreignTrendingPodcasts,
@@ -292,7 +307,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        itemWithDivider {
+                        section(liveEpisodes) {
                             EpisodesSection(
                                 title = stringResource(R.string.feature_home_section_live_episodes),
                                 episodes = liveEpisodes,
@@ -302,7 +317,7 @@ internal fun HomeScreen(
                             )
                         }
 
-                        item {
+                        section(channels) {
                             ChannelSection(
                                 title = stringResource(R.string.feature_home_section_channels),
                                 channels = channels,
@@ -323,17 +338,6 @@ internal fun HomeScreen(
                 }
             },
         )
-    }
-}
-
-fun LazyListScope.itemWithDivider(
-    key: Any? = null,
-    contentType: Any? = null,
-    content: @Composable LazyItemScope.() -> Unit,
-) {
-    item(key, contentType, content)
-    item {
-        HorizontalDivider(modifier = Modifier.padding(16.dp))
     }
 }
 

--- a/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeScreenTest.kt
+++ b/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeScreenTest.kt
@@ -97,20 +97,16 @@ class HomeScreenTest {
     }
 
     @Test
-    fun allEmptySections_showsMyRecentPublished() {
+    fun emptySection_titleIsNotShown() {
+        // 데이터가 없는 섹션은 제목만 남지 않도록 통째로 빠진다.
         setHomeScreen(
-            playingEpisodes = emptyList(),
             userRecentPodcasts = emptyList(),
             randomEpisodes = emptyList(),
-            userTrendingPodcasts = emptyList(),
-            followedPodcasts = emptyList(),
-            localTrendingPodcasts = emptyList(),
-            foreignTrendingPodcasts = emptyList(),
-            liveEpisodes = emptyList(),
-            channels = emptyList(),
         )
 
-        composeTestRule.onNodeWithText("My recent published").assertIsDisplayed()
+        composeTestRule.onNodeWithText("My recent published").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Random episodes").assertDoesNotExist()
+        composeTestRule.onNodeWithText("My trending feeds").assertIsDisplayed()
     }
 
     // --- Individual section visibility tests ---
@@ -498,7 +494,7 @@ class HomeScreenTest {
     }
 
     @Test
-    fun savedEpisodesSection_allEmpty_showsMyRecentPublished() {
+    fun allEmpty_hidesEverySectionTitle() {
         setHomeScreen(
             playingEpisodes = emptyList(),
             userRecentPodcasts = emptyList(),
@@ -511,7 +507,8 @@ class HomeScreenTest {
             channels = emptyList(),
         )
 
-        composeTestRule.onNodeWithText("My recent published").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Random episodes").assertIsDisplayed()
+        composeTestRule.onNodeWithText("My recent published").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Random episodes").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Channels worth listening to").assertDoesNotExist()
     }
 }


### PR DESCRIPTION
## 변경 사항

### 빈 섹션 숨기기
- 홈의 섹션들이 데이터와 무관하게 항상 그려져, 응답이 비어 온 섹션이 제목만 덩그러니 남아 떴다. 목록이 비면 섹션을 통째로 건너뛴다.
- 구분선을 섹션 뒤가 아니라 **앞**에 붙였다. 뒤에 두면 빈 섹션을 건너뛸 때 선이 겹치거나 마지막 섹션 뒤에 선이 남는다. 앞에 붙이면 렌더된 섹션 사이에만 선이 생긴다.
- `itemWithDivider`는 이 로컬 `section()`으로 대체돼 제거했다 (홈에서만 쓰이던 함수).

### 채널 테스트 데이터 id 중복
- `channelTestDataList = List(10) { channelTestData }` — 같은 객체 10개라 id가 전부 `1`이었다. `ChannelSection`의 `LazyRow`가 `key = { it.id }`를 쓰므로 `Key "1" was already used`로 터진다.
- 지금까지는 앞 섹션 7개 + 구분선 7개에 밀려 채널 섹션이 화면 밖이라 컴포즈되지 않아 드러나지 않았다. 빈 섹션이 빠지면서 화면 안으로 들어와 노출됐다.
- 실제 채널 id는 유일하므로 테스트 데이터도 나눠 준다.

### 테스트
- `allEmptySections_showsMyRecentPublished` / `savedEpisodesSection_allEmpty_showsMyRecentPublished` → 기대를 뒤집어 `emptySection_titleIsNotShown` / `allEmpty_hidesEverySectionTitle`로 교체. 두 테스트 모두 "모든 섹션이 비어도 제목은 보인다"를 검증하고 있었는데, 이번 변경이 없애려는 동작이 정확히 그것이다.

## 테스트

- `:app:assembleDebug` 성공
- `:core:ui` · `:core:designsystem` · `:core:testing` · `:feature:home` · `:feature:onboarding` · `:feature:library` 유닛 테스트 통과 (`--rerun-tasks`)
- 에뮬레이터(Pixel_9_Pro): 데이터 초기화 후 팟캐스트를 하나도 팔로우하지 않고 온보딩을 끝내면 **나의 인기 피드**·**구독한 팟캐스트** 두 섹션이 제목까지 사라지고, 마지막 섹션(**들어볼 만한 채널**) 뒤에 구분선이 남지 않는 것 확인

## 참고

로컬에서 `:core:database`의 `EpisodeDaoTransactionTest`·`PodcastDaoTransactionTest`가 `NoClassDefFoundError: io.mockk.impl.JvmMockKGateway`로 실패하는데, 이 PR과 무관한 로컬 JDK/MockK 환경 문제다. 해당 테스트는 채널 테스트 데이터를 쓰지 않고, 이 PR이 건드린 모듈과 의존 관계도 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LL96Tv1MgdWNvSUiGMqfyd