### PR TITLE
fix: 실패를 제대로 다루기 — 캐시 유지·에러 타입·재시도

### DIFF
--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/updater/EpisodeRemoteUpdater.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/updater/EpisodeRemoteUpdater.kt
@@ -16,7 +16,7 @@ import io.jacob.episodive.core.network.datasource.SoundbiteRemoteDataSource
 import io.jacob.episodive.core.network.mapper.toEpisodes
 import io.jacob.episodive.core.network.model.EpisodeResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
+import kotlin.time.Instant
 
 class EpisodeRemoteUpdater @AssistedInject constructor(
     private val episodeLocal: EpisodeLocalDataSource,
@@ -72,13 +72,8 @@ class EpisodeRemoteUpdater @AssistedInject constructor(
         episodeLocal.replaceEpisodes(entities, query.key)
     }
 
-    override suspend fun isExpired(): Boolean {
-        val oldestCreatedAt = episodeLocal.getOldestCreatedAtByGroupKey(query.key)
-            ?: return true
-
-        val now = Clock.System.now()
-        return now - oldestCreatedAt > query.timeToLive
-    }
+    override suspend fun getOldestCachedAt(): Instant? =
+        episodeLocal.getOldestCreatedAtByGroupKey(query.key)
 
     override fun getPagingSource(): PagingSource<Int, EpisodeWithExtrasView> {
         return episodeLocal.getEpisodesByGroupKeyPaging(query.key)

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/updater/PodcastRemoteUpdater.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/updater/PodcastRemoteUpdater.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.withIndex
-import kotlin.time.Clock
+import kotlin.time.Instant
 
 class PodcastRemoteUpdater @AssistedInject constructor(
     private val podcastLocal: PodcastLocalDataSource,
@@ -135,13 +135,8 @@ class PodcastRemoteUpdater @AssistedInject constructor(
         podcastLocal.replacePodcasts(entities, query.key)
     }
 
-    override suspend fun isExpired(): Boolean {
-        val oldestCreatedAt = podcastLocal.getOldestCreatedAtByGroupKey(query.key)
-            ?: return true
-
-        val now = Clock.System.now()
-        return now - oldestCreatedAt > query.timeToLive
-    }
+    override suspend fun getOldestCachedAt(): Instant? =
+        podcastLocal.getOldestCreatedAtByGroupKey(query.key)
 
     override fun getPagingSource(): PagingSource<Int, PodcastWithExtrasView> {
         return podcastLocal.getPodcastsByGroupKeyPaging(query.key)

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/updater/RemoteUpdater.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/updater/RemoteUpdater.kt
@@ -5,8 +5,14 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import io.jacob.episodive.core.data.util.query.CacheableQuery
+import io.jacob.episodive.core.model.DataErrorException
+import io.jacob.episodive.core.network.util.toDataError
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onStart
+import timber.log.Timber
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 abstract class RemoteUpdater<Query : CacheableQuery, Response, Entity, Output : Any>(
     protected open val query: Query,
@@ -18,7 +24,16 @@ abstract class RemoteUpdater<Query : CacheableQuery, Response, Entity, Output : 
     protected abstract suspend fun fetchFromRemote(fetchSize: Int = FETCH_SIZE): List<Response>
     protected abstract suspend fun convertToEntity(responses: List<Response>): List<Entity>
     protected abstract suspend fun replaceToLocal(entities: List<Entity>)
-    protected abstract suspend fun isExpired(): Boolean
+
+    /**
+     * 이 쿼리로 캐시된 것 중 가장 오래된 시각. 캐시가 하나도 없으면 null.
+     *
+     * 만료 여부(Boolean)가 아니라 시각을 그대로 받는다. "캐시가 없다"와 "캐시가 오래됐다"는
+     * 둘 다 갱신 대상이지만 **갱신에 실패했을 때 취할 행동이 정반대**라서, 한쪽으로 뭉뚱그리면
+     * 그 판단을 할 수 없다.
+     */
+    protected abstract suspend fun getOldestCachedAt(): Instant?
+
     protected abstract fun getPagingSource(): PagingSource<Int, Output>
     protected abstract fun getFlowSource(count: Int): Flow<List<Output>>
 
@@ -36,8 +51,24 @@ abstract class RemoteUpdater<Query : CacheableQuery, Response, Entity, Output : 
     }
 
     private suspend fun refreshIfNeeded() {
-        if (isExpired()) {
+        val cachedAt = getOldestCachedAt()
+        val expired = cachedAt == null || Clock.System.now() - cachedAt > query.timeToLive
+        if (!expired) return
+
+        try {
             refresh()
+        } catch (e: CancellationException) {
+            // 취소는 실패가 아니다. 여기서 삼키면 코루틴 취소가 전파되지 않는다.
+            throw e
+        } catch (e: Throwable) {
+            // onStart 에서 예외가 나가면 Flow 가 통째로 끊겨 DB 에 이미 있는 것까지 화면에서
+            // 사라진다. 캐시가 있으면 오래된 데이터라도 보여주는 편이 빈 화면보다 낫다.
+            // 반대로 캐시가 아예 없으면 대신 보여줄 것이 없으니, 화면이 오류를 다루도록 올린다.
+            // 이때 원인을 여기서 한 번만 판별해 실어 보낸다 — 화면마다 예외 종류를 다시
+            // 들여다보게 하면 판별 규칙이 여러 벌로 갈라진다.
+            if (cachedAt == null) throw DataErrorException(e.toDataError(), e)
+
+            Timber.e(e, "캐시 갱신에 실패해 기존 캐시를 유지한다 (key=${query.key})")
         }
     }
 

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/updater/EpisodeRemoteUpdaterTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/updater/EpisodeRemoteUpdaterTest.kt
@@ -5,6 +5,9 @@ import app.cash.turbine.test
 import io.jacob.episodive.core.data.util.query.EpisodeQuery
 import io.jacob.episodive.core.database.datasource.EpisodeLocalDataSource
 import io.jacob.episodive.core.database.datasource.SoundbiteLocalDataSource
+import io.jacob.episodive.core.database.model.EpisodeWithExtrasView
+import io.jacob.episodive.core.model.DataError
+import io.jacob.episodive.core.model.DataErrorException
 import io.jacob.episodive.core.network.datasource.EpisodeRemoteDataSource
 import io.jacob.episodive.core.network.datasource.SoundbiteRemoteDataSource
 import io.jacob.episodive.core.network.model.EpisodeResponse
@@ -15,10 +18,16 @@ import io.mockk.coVerifySequence
 import io.mockk.confirmVerified
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.net.SocketTimeoutException
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 
 class EpisodeRemoteUpdaterTest {
     @get:Rule
@@ -208,6 +217,119 @@ class EpisodeRemoteUpdaterTest {
                 episodeRemote.getEpisodesByFeedId(feedId, 1000)
                 episodeLocal.replaceEpisodes(any(), any())
                 episodeLocal.getEpisodesByGroupKeyPaging(any())
+            }
+        }
+
+    @Test
+    fun `Given cached episodes and expired cache, When remote fetch fails, Then emit cached episodes without replacing`() =
+        runTest {
+            // Given
+            val feedId = 123L
+            val query = EpisodeQuery.FeedId(feedId)
+            val updater = EpisodeRemoteUpdater(
+                episodeLocal = episodeLocal,
+                episodeRemote = episodeRemote,
+                soundbiteLocal = soundbiteLocal,
+                soundbiteRemote = soundbiteRemote,
+                query = query,
+            )
+            val cachedEpisodes = listOf(mockk<EpisodeWithExtrasView>(relaxed = true))
+            coEvery {
+                episodeLocal.getEpisodesByGroupKey(any(), any())
+            } returns flowOf(cachedEpisodes)
+            coEvery {
+                episodeLocal.getOldestCreatedAtByGroupKey(any())
+            } returns Clock.System.now() - 2.days
+            coEvery {
+                episodeRemote.getEpisodesByFeedId(any(), any())
+            } throws RuntimeException("network error")
+
+            // When & Then
+            // 원격 갱신이 실패해도 Flow 가 끊기지 않고 캐시가 그대로 방출돼야 한다.
+            updater.getFlowList(count = 10).test {
+                assertEquals(cachedEpisodes, awaitItem())
+                awaitComplete()
+            }
+
+            coVerifySequence {
+                episodeLocal.getEpisodesByGroupKey(any(), 10)
+                episodeLocal.getOldestCreatedAtByGroupKey(any())
+                episodeRemote.getEpisodesByFeedId(feedId, 1000)
+            }
+        }
+
+    @Test
+    fun `Given no cached episodes, When remote fetch fails, Then propagate the error`() =
+        runTest {
+            // Given
+            val feedId = 123L
+            val query = EpisodeQuery.FeedId(feedId)
+            val updater = EpisodeRemoteUpdater(
+                episodeLocal = episodeLocal,
+                episodeRemote = episodeRemote,
+                soundbiteLocal = soundbiteLocal,
+                soundbiteRemote = soundbiteRemote,
+                query = query,
+            )
+            // SocketTimeoutException 을 던져 toDataError() 판별이 실제로 동작하는지까지 고정한다.
+            val error = SocketTimeoutException("network error")
+            coEvery {
+                episodeLocal.getEpisodesByGroupKey(any(), any())
+            } returns flowOf(emptyList())
+            coEvery {
+                episodeLocal.getOldestCreatedAtByGroupKey(any())
+            } returns null
+            coEvery {
+                episodeRemote.getEpisodesByFeedId(any(), any())
+            } throws error
+
+            // When & Then
+            // 보여줄 캐시가 없으면 예외를 삼키지 않고, 판별된 DataError 와 원인을 실어 올린다.
+            updater.getFlowList(count = 10).test {
+                val thrown = awaitError()
+                assertTrue(thrown is DataErrorException)
+                assertEquals(error, (thrown as DataErrorException).cause)
+                assertEquals(DataError.Timeout, thrown.error)
+            }
+
+            coVerifySequence {
+                episodeLocal.getEpisodesByGroupKey(any(), 10)
+                episodeLocal.getOldestCreatedAtByGroupKey(any())
+                episodeRemote.getEpisodesByFeedId(feedId, 1000)
+            }
+        }
+
+    @Test
+    fun `Given cached episodes within TTL, When getFlowList called, Then skip remote fetch`() =
+        runTest {
+            // Given
+            val feedId = 123L
+            val query = EpisodeQuery.FeedId(feedId)
+            val updater = EpisodeRemoteUpdater(
+                episodeLocal = episodeLocal,
+                episodeRemote = episodeRemote,
+                soundbiteLocal = soundbiteLocal,
+                soundbiteRemote = soundbiteRemote,
+                query = query,
+            )
+            val cachedEpisodes = listOf(mockk<EpisodeWithExtrasView>(relaxed = true))
+            coEvery {
+                episodeLocal.getEpisodesByGroupKey(any(), any())
+            } returns flowOf(cachedEpisodes)
+            coEvery {
+                episodeLocal.getOldestCreatedAtByGroupKey(any())
+            } returns Clock.System.now()
+
+            // When
+            updater.getFlowList(count = 10).test {
+                assertEquals(cachedEpisodes, awaitItem())
+                awaitComplete()
+            }
+
+            // Then: TTL 이내라 원격 갱신을 아예 호출하지 않는다.
+            coVerifySequence {
+                episodeLocal.getEpisodesByGroupKey(any(), 10)
+                episodeLocal.getOldestCreatedAtByGroupKey(any())
             }
         }
 

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/updater/PodcastRemoteUpdaterTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/updater/PodcastRemoteUpdaterTest.kt
@@ -4,8 +4,11 @@ import androidx.paging.PagingConfig
 import app.cash.turbine.test
 import io.jacob.episodive.core.data.util.query.PodcastQuery
 import io.jacob.episodive.core.database.datasource.PodcastLocalDataSource
+import io.jacob.episodive.core.database.model.PodcastWithExtrasView
 import io.jacob.episodive.core.model.Category
 import io.jacob.episodive.core.model.Channel
+import io.jacob.episodive.core.model.DataError
+import io.jacob.episodive.core.model.DataErrorException
 import io.jacob.episodive.core.model.Medium
 import io.jacob.episodive.core.network.datasource.FeedRemoteDataSource
 import io.jacob.episodive.core.network.datasource.PodcastRemoteDataSource
@@ -20,10 +23,16 @@ import io.mockk.coVerifySequence
 import io.mockk.confirmVerified
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.net.SocketTimeoutException
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 class PodcastRemoteUpdaterTest {
     @get:Rule
@@ -78,6 +87,116 @@ class PodcastRemoteUpdaterTest {
                 podcastLocal.getOldestCreatedAtByGroupKey("feedId:123")
                 podcastRemote.getPodcastByFeedId(any())
                 podcastLocal.replacePodcasts(any(), "feedId:123")
+            }
+        }
+
+    @Test
+    fun `Given cached podcasts and expired cache, When remote fetch fails, Then emit cached podcasts without replacing`() =
+        runTest {
+            // Given
+            val feedId = 123L
+            val query = PodcastQuery.FeedId(feedId)
+            val updater = PodcastRemoteUpdater(
+                podcastLocal = podcastLocal,
+                podcastRemote = podcastRemote,
+                feedRemote = feedRemote,
+                query = query,
+            )
+            val cachedPodcasts = listOf(mockk<PodcastWithExtrasView>(relaxed = true))
+            coEvery {
+                podcastLocal.getPodcastsByGroupKey(any(), any())
+            } returns flowOf(cachedPodcasts)
+            coEvery {
+                podcastLocal.getOldestCreatedAtByGroupKey(any())
+            } returns Clock.System.now() - 2.hours
+            coEvery {
+                podcastRemote.getPodcastByFeedId(any())
+            } throws RuntimeException("network error")
+
+            // When & Then
+            // 원격 갱신이 실패해도 Flow 가 끊기지 않고 캐시가 그대로 방출돼야 한다.
+            updater.getFlowList(count = 10).test {
+                assertEquals(cachedPodcasts, awaitItem())
+                awaitComplete()
+            }
+
+            coVerifySequence {
+                podcastLocal.getPodcastsByGroupKey("feedId:123", 10)
+                podcastLocal.getOldestCreatedAtByGroupKey("feedId:123")
+                podcastRemote.getPodcastByFeedId(any())
+            }
+        }
+
+    @Test
+    fun `Given no cached podcasts, When remote fetch fails, Then propagate the error`() =
+        runTest {
+            // Given
+            val feedId = 123L
+            val query = PodcastQuery.FeedId(feedId)
+            val updater = PodcastRemoteUpdater(
+                podcastLocal = podcastLocal,
+                podcastRemote = podcastRemote,
+                feedRemote = feedRemote,
+                query = query,
+            )
+            // SocketTimeoutException 을 던져 toDataError() 판별이 실제로 동작하는지까지 고정한다.
+            val error = SocketTimeoutException("network error")
+            coEvery {
+                podcastLocal.getPodcastsByGroupKey(any(), any())
+            } returns flowOf(emptyList())
+            coEvery {
+                podcastLocal.getOldestCreatedAtByGroupKey(any())
+            } returns null
+            coEvery {
+                podcastRemote.getPodcastByFeedId(any())
+            } throws error
+
+            // When & Then
+            // 보여줄 캐시가 없으면 예외를 삼키지 않고, 판별된 DataError 와 원인을 실어 올린다.
+            updater.getFlowList(count = 10).test {
+                val thrown = awaitError()
+                assertTrue(thrown is DataErrorException)
+                assertEquals(error, (thrown as DataErrorException).cause)
+                assertEquals(DataError.Timeout, thrown.error)
+            }
+
+            coVerifySequence {
+                podcastLocal.getPodcastsByGroupKey("feedId:123", 10)
+                podcastLocal.getOldestCreatedAtByGroupKey("feedId:123")
+                podcastRemote.getPodcastByFeedId(any())
+            }
+        }
+
+    @Test
+    fun `Given cached podcasts within TTL, When getFlowList called, Then skip remote fetch`() =
+        runTest {
+            // Given
+            val feedId = 123L
+            val query = PodcastQuery.FeedId(feedId)
+            val updater = PodcastRemoteUpdater(
+                podcastLocal = podcastLocal,
+                podcastRemote = podcastRemote,
+                feedRemote = feedRemote,
+                query = query,
+            )
+            val cachedPodcasts = listOf(mockk<PodcastWithExtrasView>(relaxed = true))
+            coEvery {
+                podcastLocal.getPodcastsByGroupKey(any(), any())
+            } returns flowOf(cachedPodcasts)
+            coEvery {
+                podcastLocal.getOldestCreatedAtByGroupKey(any())
+            } returns Clock.System.now()
+
+            // When
+            updater.getFlowList(count = 10).test {
+                assertEquals(cachedPodcasts, awaitItem())
+                awaitComplete()
+            }
+
+            // Then: TTL 이내라 원격 갱신을 아예 호출하지 않는다.
+            coVerifySequence {
+                podcastLocal.getPodcastsByGroupKey("feedId:123", 10)
+                podcastLocal.getOldestCreatedAtByGroupKey("feedId:123")
             }
         }
 

--- a/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/screen/ErrorScreen.kt
+++ b/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/screen/ErrorScreen.kt
@@ -1,32 +1,79 @@
 package io.jacob.episodive.core.designsystem.screen
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import io.jacob.episodive.core.designsystem.R
+import io.jacob.episodive.core.designsystem.component.EpisodiveButton
 import io.jacob.episodive.core.designsystem.theme.EpisodiveTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 
+/**
+ * 화면 전체가 실패했을 때의 자리.
+ *
+ * [onRetry] 를 주지 않으면 버튼 없이 문구만 그린다. 다시 시도해도 같은 답이 오는 실패
+ * (없는 대상, 인증 실패)에서는 버튼을 두지 않는 편이 낫다 — 눌러도 아무 일이 없으면 앱이
+ * 고장 난 것처럼 보인다.
+ */
 @Composable
 fun ErrorScreen(
     modifier: Modifier = Modifier,
     message: String,
+    onRetry: (() -> Unit)? = null,
 ) {
-    Box(
+    Column(
         modifier = modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
+            .padding(horizontal = ErrorScreenHorizontalPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
-        Text(text = message)
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+
+        if (onRetry != null) {
+            Column(
+                modifier = Modifier.padding(top = ErrorScreenActionSpacing),
+            ) {
+                EpisodiveButton(onClick = onRetry) {
+                    Text(text = stringResource(R.string.core_designsystem_retry))
+                }
+            }
+        }
     }
 }
+
+private val ErrorScreenHorizontalPadding = 32.dp
+private val ErrorScreenActionSpacing = 20.dp
 
 @DevicePreviews
 @Composable
 private fun ErrorScreenPreview() {
     EpisodiveTheme {
-        ErrorScreen(message = "An error occurred")
+        ErrorScreen(
+            message = "연결이 끊겼어요.\n네트워크를 확인하고 다시 시도해 주세요.",
+            onRetry = {},
+        )
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun ErrorScreenWithoutRetryPreview() {
+    EpisodiveTheme {
+        ErrorScreen(message = "요청한 팟캐스트를 찾을 수 없어요.")
     }
 }

--- a/core/designsystem/src/main/res/values-ko/strings.xml
+++ b/core/designsystem/src/main/res/values-ko/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="core_designsystem_loading">콘텐츠를 불러오는 중</string>
+    <string name="core_designsystem_retry">다시 시도</string>
 </resources>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="core_designsystem_loading">Loading content</string>
+    <string name="core_designsystem_retry">Try again</string>
 </resources>

--- a/core/model/src/main/kotlin/io/jacob/episodive/core/model/DataError.kt
+++ b/core/model/src/main/kotlin/io/jacob/episodive/core/model/DataError.kt
@@ -1,0 +1,64 @@
+package io.jacob.episodive.core.model
+
+/**
+ * 화면이 사용자에게 설명할 수 있는 수준으로 추린 실패 원인.
+ *
+ * 예외 메시지를 그대로 화면에 올리면 세 가지가 한꺼번에 깨진다 — 현지화가 되지 않고, 사용자가
+ * 무엇을 해야 할지 알 수 없고("timeout"), HTTP 스택 내부가 밖으로 샌다. 그래서 데이터 계층의
+ * 예외를 여기서 몇 갈래로 접어 올린다.
+ *
+ * 갈래를 더 잘게 쪼개지 않는 이유는 **사용자가 취할 행동이 같으면 같은 원인**이기 때문이다.
+ * 연결이 끊긴 것과 DNS 가 실패한 것은 원인이 다르지만 사용자에겐 똑같이 "네트워크를 확인하라"다.
+ */
+sealed interface DataError {
+    /** 기기가 네트워크에 닿지 못한다. 사용자가 직접 조치할 수 있는 유일한 갈래다. */
+    data object Offline : DataError
+
+    /** 연결은 됐지만 응답이 제때 오지 않았다. 다시 시도하면 될 가능성이 있다. */
+    data object Timeout : DataError
+
+    /** 서버가 5xx 로 응답했다. 사용자가 할 수 있는 건 기다렸다 다시 시도하는 것뿐이다. */
+    data object Server : DataError
+
+    /** 인증 실패(401·403). API 키 설정 문제이지 사용자 잘못이 아니다. */
+    data object Unauthorized : DataError
+
+    /** 요청한 대상이 없다. 재시도해도 결과가 같다 — 화면이 재시도 버튼을 감출 근거가 된다. */
+    data object NotFound : DataError
+
+    /** 위 어디에도 들지 않는 것. 원인 추적을 위해 원본을 들고 있는다. */
+    data class Unexpected(val throwable: Throwable?) : DataError
+}
+
+/**
+ * 다시 시도해서 결과가 달라질 수 있는 실패인지.
+ *
+ * [DataError.NotFound] 와 [DataError.Unauthorized] 는 같은 요청을 반복해도 같은 답이 온다.
+ * 이런 화면에 재시도 버튼을 두면 눌러도 아무 일이 없어 앱이 고장 난 것처럼 보인다.
+ */
+val DataError.isRetryable: Boolean
+    get() = when (this) {
+        DataError.Offline, DataError.Timeout, DataError.Server -> true
+        DataError.NotFound, DataError.Unauthorized -> false
+        is DataError.Unexpected -> true
+    }
+
+/**
+ * 판별이 끝난 [DataError] 를 Flow 밖으로 실어 나르기 위한 예외.
+ *
+ * 데이터 계층에서 한 번만 판별하고 그 결과를 그대로 올린다. 화면마다 예외 종류를 다시 들여다보게
+ * 하면 판별 규칙이 여러 벌로 갈라지고, 무엇보다 화면이 HTTP 스택을 알아야 한다.
+ */
+class DataErrorException(
+    val error: DataError,
+    override val cause: Throwable? = null,
+) : Exception(cause)
+
+/**
+ * 화면에서 잡은 예외를 표시 가능한 원인으로 되돌린다.
+ *
+ * 데이터 계층을 거쳐 온 것이면 이미 판별된 값이 들어 있고, 그렇지 않은 것(화면·도메인 계층에서
+ * 난 예외)은 [DataError.Unexpected] 로 떨어진다.
+ */
+fun Throwable.asDataError(): DataError =
+    (this as? DataErrorException)?.error ?: DataError.Unexpected(this)

--- a/core/network/src/main/kotlin/io/jacob/episodive/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/io/jacob/episodive/core/network/di/NetworkModule.kt
@@ -15,12 +15,20 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class RetrofitOkHttpClient
+
+private const val CONNECT_TIMEOUT_SECONDS = 15L
+private const val READ_TIMEOUT_SECONDS = 30L
+private const val WRITE_TIMEOUT_SECONDS = 15L
+
+/** 단계별 타임아웃과 별개로 요청 하나가 쓸 수 있는 전체 상한. */
+private const val CALL_TIMEOUT_SECONDS = 40L
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -31,6 +39,14 @@ object NetworkModule {
     fun provideRetrofitOkHttpClient(): OkHttpClient {
         val builder = OkHttpClient.Builder()
             .addInterceptor(EpisodiveInterceptor())
+            // 기본값(각 단계 10초, 전체 무제한)에 기대지 않고 명시한다. 특히 callTimeout 은
+            // 기본이 무제한이라, 단계마다 조금씩 진행되는 느린 연결에서는 어떤 타임아웃에도
+            // 걸리지 않고 무한히 기다릴 수 있다. 목록 API 는 한 번에 최대 1000건을 받으므로
+            // read 는 기본보다 넉넉히 준다.
+            .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 
         if (BuildConfig.DEBUG) {
             builder.addInterceptor(

--- a/core/network/src/main/kotlin/io/jacob/episodive/core/network/util/NetworkErrorMapper.kt
+++ b/core/network/src/main/kotlin/io/jacob/episodive/core/network/util/NetworkErrorMapper.kt
@@ -1,0 +1,40 @@
+package io.jacob.episodive.core.network.util
+
+import io.jacob.episodive.core.model.DataError
+import retrofit2.HttpException
+import java.io.InterruptedIOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+private const val HTTP_UNAUTHORIZED = 401
+private const val HTTP_FORBIDDEN = 403
+private const val HTTP_NOT_FOUND = 404
+private val SERVER_ERROR_RANGE = 500..599
+
+/**
+ * 네트워크 계층의 예외를 화면이 설명할 수 있는 원인으로 접는다.
+ *
+ * 이 프로젝트의 API 인터페이스는 `Response<T>` 로 감싸지 않고 본문 타입을 그대로 반환한다.
+ * 그래서 4xx·5xx 는 `isSuccessful` 로 조용히 오는 것이 아니라 Retrofit 이 [HttpException] 을
+ * 던지는 경로로만 나타난다.
+ *
+ * 취소는 여기서 다루지 않는다 — 호출부가 [kotlinx.coroutines.CancellationException] 을 먼저
+ * 걸러 다시 던져야 한다. 취소를 실패로 접으면 코루틴 취소가 전파되지 않는다.
+ */
+fun Throwable.toDataError(): DataError = when (this) {
+    is UnknownHostException, is ConnectException -> DataError.Offline
+
+    // SocketTimeoutException 은 InterruptedIOException 의 하위 타입이다. 둘 다 같은 갈래로
+    // 접히므로 순서는 결과에 영향을 주지 않는다.
+    is SocketTimeoutException, is InterruptedIOException -> DataError.Timeout
+
+    is HttpException -> when (code()) {
+        HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> DataError.Unauthorized
+        HTTP_NOT_FOUND -> DataError.NotFound
+        in SERVER_ERROR_RANGE -> DataError.Server
+        else -> DataError.Unexpected(this)
+    }
+
+    else -> DataError.Unexpected(this)
+}

--- a/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/DataErrorMessage.kt
+++ b/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/DataErrorMessage.kt
@@ -1,0 +1,23 @@
+package io.jacob.episodive.core.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import io.jacob.episodive.core.model.DataError
+
+/**
+ * 실패 원인을 사용자에게 보여줄 문장으로 옮긴다.
+ *
+ * 문구는 "무엇이 잘못됐는지"보다 **"이제 무엇을 하면 되는지"** 를 담는다. 원인을 정확히
+ * 알려줘도 다음 행동을 모르면 사용자에게는 막다른 길이다.
+ */
+@Composable
+fun DataError.asUiMessage(): String = stringResource(
+    when (this) {
+        DataError.Offline -> R.string.core_ui_error_offline
+        DataError.Timeout -> R.string.core_ui_error_timeout
+        DataError.Server -> R.string.core_ui_error_server
+        DataError.Unauthorized -> R.string.core_ui_error_unauthorized
+        DataError.NotFound -> R.string.core_ui_error_not_found
+        is DataError.Unexpected -> R.string.core_ui_error_unexpected
+    }
+)

--- a/core/ui/src/main/res/values-ko/strings.xml
+++ b/core/ui/src/main/res/values-ko/strings.xml
@@ -7,6 +7,13 @@
     <string name="core_ui_follow">팔로우하기</string>
     <string name="core_ui_unfollow">팔로잉</string>
 
+    <string name="core_ui_error_offline">네트워크에 연결되어 있지 않은 것 같아요.\n연결을 확인하고 다시 시도해 주세요.</string>
+    <string name="core_ui_error_timeout">응답이 너무 늦어지고 있어요.\n잠시 후 다시 시도해 주세요.</string>
+    <string name="core_ui_error_server">서버에 문제가 생겼어요.\n잠시 후 다시 시도해 주세요.</string>
+    <string name="core_ui_error_unauthorized">서비스 인증에 실패했어요.\n계속 이러면 알려주세요.</string>
+    <string name="core_ui_error_not_found">찾으시는 내용을 찾지 못했어요.</string>
+    <string name="core_ui_error_unexpected">문제가 생겼어요.\n잠시 후 다시 시도해 주세요.</string>
+
     <!--
       Category enum(:core:model)의 선언 순서와 1:1로 대응한다 — ordinal 을 인덱스로 조회하므로
       항목을 중간에 끼워넣거나 순서를 바꾸지 말 것. 새 카테고리는 항상 끝에 추가한다.

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="core_ui_episodes">episodes</string>
+
+    <string name="core_ui_error_offline">You appear to be offline.\nCheck your connection and try again.</string>
+    <string name="core_ui_error_timeout">The response is taking too long.\nPlease try again in a moment.</string>
+    <string name="core_ui_error_server">Something went wrong on our end.\nPlease try again in a moment.</string>
+    <string name="core_ui_error_unauthorized">Couldn\'t sign in to the service.\nIf this keeps happening, please let us know.</string>
+    <string name="core_ui_error_not_found">We couldn\'t find what you were looking for.</string>
+    <string name="core_ui_error_unexpected">Something went wrong.\nPlease try again in a moment.</string>
     <string name="core_ui_continue">Continue</string>
     <string name="core_ui_completed">Completed</string>
     <string name="core_ui_left">Left</string>

--- a/feature/channel/src/main/kotlin/io/jacob/episodive/feature/channel/ChannelScreen.kt
+++ b/feature/channel/src/main/kotlin/io/jacob/episodive/feature/channel/ChannelScreen.kt
@@ -60,8 +60,10 @@ import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Channel
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.channelTestData
 import io.jacob.episodive.core.testing.model.podcastTestDataList
+import io.jacob.episodive.core.ui.asUiMessage
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -98,7 +100,16 @@ internal fun ChannelRoute(
             )
         }
 
-        is ChannelState.Error -> ErrorScreen(message = s.message)
+        is ChannelState.Error -> ErrorScreen(
+            message = s.error.asUiMessage(),
+            // NotFound 는 재시도해도 결과가 같으므로 버튼을 감춘다 — 눌러도 아무 일이
+            // 없으면 앱이 고장 난 것처럼 보인다.
+            onRetry = if (s.error.isRetryable) {
+                { viewModel.sendAction(ChannelAction.Retry) }
+            } else {
+                null
+            },
+        )
     }
 }
 

--- a/feature/channel/src/main/kotlin/io/jacob/episodive/feature/channel/ChannelViewModel.kt
+++ b/feature/channel/src/main/kotlin/io/jacob/episodive/feature/channel/ChannelViewModel.kt
@@ -9,18 +9,23 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.jacob.episodive.core.domain.usecase.channel.GetChannelByIdUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetPodcastsByChannelUseCase
 import io.jacob.episodive.core.model.Channel
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.asDataError
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @HiltViewModel(assistedFactory = ChannelViewModel.Factory::class)
 class ChannelViewModel @AssistedInject constructor(
@@ -33,26 +38,32 @@ class ChannelViewModel @AssistedInject constructor(
         fun create(@Assisted("id") id: Long): ChannelViewModel
     }
 
-    private val channel = getChannelByIdUseCase(id)
-    private val podcasts = channel.flatMapLatest {
-        if (it == null) emptyFlow() else getPodcastsByChannelUseCase(it)
-    }
+    // 재시도는 소스 체인을 통째로 재구독해야 한다. 아래 체인은 전부 콜드 Flow라
+    // 재구독해도 부작용이 없다는 걸 확인했다.
+    private val retryTrigger = MutableStateFlow(0)
 
-    val state: StateFlow<ChannelState> = combine(
-        channel,
-        podcasts,
-    ) { channel, podcasts ->
-        if (channel == null) {
-            ChannelState.Error("Channel not found")
-        } else {
-            ChannelState.Success(
-                channel = channel,
-                podcasts = podcasts,
-            )
+    val state: StateFlow<ChannelState> = retryTrigger.flatMapLatest {
+        val channel = getChannelByIdUseCase(id)
+        // channel 이 null 일 때 emptyFlow() 를 주면 combine 이 값을 한 번도 내보내지 않아
+        // 아래 not-found 분기가 영원히 도달하지 않는다(Loading 에 영구히 멈춤). flowOf 로
+        // 빈 리스트를 한 번 방출해야 combine 이 실제로 값을 낸다.
+        val podcasts = channel.flatMapLatest { c ->
+            if (c == null) flowOf(emptyList()) else getPodcastsByChannelUseCase(c)
         }
-    }.catch { e ->
-        emit(ChannelState.Error(e.message ?: "An unknown error occurred"))
-        e.printStackTrace()
+
+        combine(channel, podcasts) { c, p ->
+            if (c == null) {
+                ChannelState.Error(DataError.NotFound)
+            } else {
+                ChannelState.Success(
+                    channel = c,
+                    podcasts = p,
+                )
+            }
+        }.catch { e ->
+            Timber.e(e, "채널을 불러오지 못했다 (id=$id)")
+            emit(ChannelState.Error(e.asDataError()))
+        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -73,6 +84,7 @@ class ChannelViewModel @AssistedInject constructor(
             when (action) {
                 is ChannelAction.ClickBack -> clickBack()
                 is ChannelAction.ClickPodcast -> clickPodcast(action.podcastId)
+                is ChannelAction.Retry -> retry()
             }
         }
     }
@@ -88,6 +100,10 @@ class ChannelViewModel @AssistedInject constructor(
     private fun clickPodcast(podcastId: Long) = viewModelScope.launch {
         _effect.emit(ChannelEffect.NavigateToPodcast(podcastId))
     }
+
+    private fun retry() {
+        retryTrigger.update { it + 1 }
+    }
 }
 
 sealed interface ChannelState {
@@ -97,12 +113,13 @@ sealed interface ChannelState {
         val podcasts: List<Podcast>,
     ) : ChannelState
 
-    data class Error(val message: String) : ChannelState
+    data class Error(val error: DataError) : ChannelState
 }
 
 sealed interface ChannelAction {
     data object ClickBack : ChannelAction
     data class ClickPodcast(val podcastId: Long) : ChannelAction
+    data object Retry : ChannelAction
 }
 
 sealed interface ChannelEffect {

--- a/feature/channel/src/test/kotlin/io/jacob/episodive/feature/channel/ChannelViewModelTest.kt
+++ b/feature/channel/src/test/kotlin/io/jacob/episodive/feature/channel/ChannelViewModelTest.kt
@@ -3,12 +3,16 @@ package io.jacob.episodive.feature.channel
 import app.cash.turbine.test
 import io.jacob.episodive.core.domain.usecase.channel.GetChannelByIdUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetPodcastsByChannelUseCase
+import io.jacob.episodive.core.model.DataError
+import io.jacob.episodive.core.model.DataErrorException
 import io.jacob.episodive.core.testing.model.channelTestData
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.core.testing.util.MainDispatcherRule
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -59,30 +63,54 @@ class ChannelViewModelTest {
     }
 
     @Test
-    fun `Given null channel, When flow emits, Then state remains Loading because podcasts flow never emits`() =
-        runTest {
-            every { getChannelByIdUseCase(1L) } returns flowOf(null)
-
-            val viewModel = createViewModel()
-
-            // When channel is null, podcasts becomes emptyFlow(), so combine never fires
-            assertEquals(ChannelState.Loading, viewModel.state.value)
-        }
-
-    @Test
-    fun `Given flow throws exception, When collecting, Then state is Error`() = runTest {
-        every { getChannelByIdUseCase(1L) } returns kotlinx.coroutines.flow.flow {
-            throw RuntimeException("Network error")
-        }
+    fun `Given null channel, When flow emits, Then state is Error with NotFound`() = runTest {
+        every { getChannelByIdUseCase(1L) } returns flowOf(null)
 
         val viewModel = createViewModel()
 
         viewModel.state.test {
             val state = awaitItem()
             assertTrue(state is ChannelState.Error)
-            assertEquals("Network error", (state as ChannelState.Error).message)
+            assertEquals(DataError.NotFound, (state as ChannelState.Error).error)
         }
     }
+
+    @Test
+    fun `Given flow throws unrecognized exception, When collecting, Then state is Error with Unexpected`() =
+        runTest {
+            val exception = RuntimeException("Network error")
+            every { getChannelByIdUseCase(1L) } returns kotlinx.coroutines.flow.flow {
+                throw exception
+            }
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is ChannelState.Error)
+                val error = (state as ChannelState.Error).error
+                assertTrue(error is DataError.Unexpected)
+                // coroutine 경계를 넘을 때 kotlinx.coroutines 가 스택트레이스 복구를 위해
+                // 예외를 복제할 수 있어 참조(exception) 동일성이 아니라 내용으로 비교한다.
+                assertEquals(exception.message, (error as DataError.Unexpected).throwable?.message)
+            }
+        }
+
+    @Test
+    fun `Given flow throws DataErrorException, When collecting, Then state is Error with the mapped DataError`() =
+        runTest {
+            every { getChannelByIdUseCase(1L) } returns kotlinx.coroutines.flow.flow {
+                throw DataErrorException(DataError.Offline)
+            }
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is ChannelState.Error)
+                assertEquals(DataError.Offline, (state as ChannelState.Error).error)
+            }
+        }
 
     @Test
     fun `Given valid channel with empty podcasts, When flows emit, Then state is Success with empty list`() =
@@ -128,4 +156,26 @@ class ChannelViewModelTest {
                 assertEquals(ChannelEffect.NavigateToPodcast(42L), awaitItem())
             }
         }
+
+    @Test
+    fun `Given Retry action, When sent, Then upstream flow chain is resubscribed`() = runTest {
+        every { getChannelByIdUseCase(1L) } returns flowOf(channelTestData)
+        every { getPodcastsByChannelUseCase(any()) } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+
+        viewModel.state.test {
+            assertTrue(awaitItem() is ChannelState.Success)
+
+            viewModel.sendAction(ChannelAction.Retry)
+            advanceUntilIdle()
+
+            // retryTrigger 가 바뀌면 flatMapLatest 가 상위 체인(getChannelByIdUseCase 호출부터)을
+            // 통째로 재구독한다. Success 값 자체는 이전과 구조적으로 같아 StateFlow가 재방출을
+            // 걸러내므로, 두 번째 awaitItem() 대신 UseCase 호출 횟수로 재구독을 검증한다.
+            verify(exactly = 2) { getChannelByIdUseCase(1L) }
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
@@ -74,6 +74,7 @@ import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Channel
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.model.mapper.toHumanReadable
 import io.jacob.episodive.core.testing.model.channelTestDataList
 import io.jacob.episodive.core.testing.model.episodeTestDataList
@@ -85,6 +86,7 @@ import io.jacob.episodive.core.ui.EpisodesSection
 import io.jacob.episodive.core.ui.EpisodesSectionSkeleton
 import io.jacob.episodive.core.ui.PodcastsSection
 import io.jacob.episodive.core.ui.PodcastsSectionSkeleton
+import io.jacob.episodive.core.ui.asUiMessage
 
 
 @Composable
@@ -136,7 +138,14 @@ internal fun HomeRoute(
             onChannelClick = { viewModel.sendAction(HomeAction.ClickChannel(it)) },
         )
 
-        is HomeState.Error -> ErrorScreen(message = s.message)
+        is HomeState.Error -> ErrorScreen(
+            message = s.error.asUiMessage(),
+            onRetry = if (s.error.isRetryable) {
+                { viewModel.sendAction(HomeAction.Retry) }
+            } else {
+                null
+            },
+        )
     }
 }
 

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeViewModel.kt
@@ -18,16 +18,22 @@ import io.jacob.episodive.core.domain.usecase.podcast.GetLocalTrendingPodcastsUs
 import io.jacob.episodive.core.domain.usecase.podcast.GetUserRecentPodcastsUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetUserTrendingPodcastsUseCase
 import io.jacob.episodive.core.model.Channel
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.asDataError
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -47,42 +53,48 @@ class HomeViewModel @Inject constructor(
     private val saveEpisodeUseCase: SaveEpisodeUseCase,
 ) : ViewModel() {
 
-    val state: StateFlow<HomeState> = combine(
-        getPlayingEpisodesUseCase(max = FEED_MAX),
-        getUserRecentPodcastsUseCase(max = FEED_MAX),
-        getMyRandomEpisodesUseCase(max = COMPACT_MAX),
-        getUserTrendingPodcastsUseCase(max = FEED_MAX),
-        getFollowedPodcastsUseCase(max = FEED_MAX),
-        getLocalTrendingPodcastsUseCase(max = FEED_MAX),
-        getForeignTrendingPodcastsUseCase(max = FEED_MAX),
-        getLiveEpisodesUseCase(max = COMPACT_MAX),
-        getChannelsUseCase(),
-    ) {
-            playingEpisodes,
-            userRecentPodcasts,
-            randomEpisodes,
-            userTrendingPodcasts,
-            followedPodcasts,
-            localTrendingPodcasts,
-            foreignTrendingPodcasts,
-            liveEpisodes,
-            channels,
-        ->
+    // 재시도 시 9개 소스 전부를 다시 구독해야 해서 combine 전체를 flatMapLatest 로 감싼다.
+    // 값을 증가시키기만 하면 되므로 트리거 자체의 내용은 의미가 없다.
+    private val retryTrigger = MutableStateFlow(0)
 
-        HomeState.Success(
-            playingEpisodes = playingEpisodes,
-            userRecentPodcasts = userRecentPodcasts,
-            randomEpisodes = randomEpisodes,
-            userTrendingPodcasts = userTrendingPodcasts,
-            followedPodcasts = followedPodcasts,
-            localTrendingPodcasts = localTrendingPodcasts,
-            foreignTrendingPodcasts = foreignTrendingPodcasts,
-            liveEpisodes = liveEpisodes,
-            channels = channels
-        ) as HomeState
-    }.catch { e ->
-        emit(HomeState.Error(e.message ?: "An unknown error occurred"))
-        e.printStackTrace()
+    val state: StateFlow<HomeState> = retryTrigger.flatMapLatest {
+        combine(
+            getPlayingEpisodesUseCase(max = FEED_MAX),
+            getUserRecentPodcastsUseCase(max = FEED_MAX),
+            getMyRandomEpisodesUseCase(max = COMPACT_MAX),
+            getUserTrendingPodcastsUseCase(max = FEED_MAX),
+            getFollowedPodcastsUseCase(max = FEED_MAX),
+            getLocalTrendingPodcastsUseCase(max = FEED_MAX),
+            getForeignTrendingPodcastsUseCase(max = FEED_MAX),
+            getLiveEpisodesUseCase(max = COMPACT_MAX),
+            getChannelsUseCase(),
+        ) {
+                playingEpisodes,
+                userRecentPodcasts,
+                randomEpisodes,
+                userTrendingPodcasts,
+                followedPodcasts,
+                localTrendingPodcasts,
+                foreignTrendingPodcasts,
+                liveEpisodes,
+                channels,
+            ->
+
+            HomeState.Success(
+                playingEpisodes = playingEpisodes,
+                userRecentPodcasts = userRecentPodcasts,
+                randomEpisodes = randomEpisodes,
+                userTrendingPodcasts = userTrendingPodcasts,
+                followedPodcasts = followedPodcasts,
+                localTrendingPodcasts = localTrendingPodcasts,
+                foreignTrendingPodcasts = foreignTrendingPodcasts,
+                liveEpisodes = liveEpisodes,
+                channels = channels
+            ) as HomeState
+        }.catch { e ->
+            Timber.e(e, "홈 데이터를 불러오지 못했다")
+            emit(HomeState.Error(e.asDataError()))
+        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -107,6 +119,7 @@ class HomeViewModel @Inject constructor(
                 is HomeAction.ToggleSavedEpisode -> toggleSavedEpisode(action.episode)
                 is HomeAction.ClickPodcast -> clickPodcast(action.podcastId)
                 is HomeAction.ClickChannel -> clickChannel(action.channelId)
+                is HomeAction.Retry -> retry()
             }
         }
     }
@@ -142,6 +155,10 @@ class HomeViewModel @Inject constructor(
         _effect.emit(HomeEffect.NavigateToChannel(channelId))
     }
 
+    private fun retry() {
+        retryTrigger.update { it + 1 }
+    }
+
     companion object {
         private const val FEED_MAX = 10
         private const val COMPACT_MAX = 6
@@ -162,7 +179,7 @@ sealed interface HomeState {
         val channels: List<Channel>,
     ) : HomeState
 
-    data class Error(val message: String) : HomeState
+    data class Error(val error: DataError) : HomeState
 }
 
 sealed interface HomeAction {
@@ -172,6 +189,7 @@ sealed interface HomeAction {
     data class ToggleSavedEpisode(val episode: Episode) : HomeAction
     data class ClickPodcast(val podcastId: Long) : HomeAction
     data class ClickChannel(val channelId: Long) : HomeAction
+    data object Retry : HomeAction
 }
 
 sealed interface HomeEffect {

--- a/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeViewModelTest.kt
+++ b/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeViewModelTest.kt
@@ -14,6 +14,7 @@ import io.jacob.episodive.core.domain.usecase.podcast.GetForeignTrendingPodcasts
 import io.jacob.episodive.core.domain.usecase.podcast.GetLocalTrendingPodcastsUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetUserRecentPodcastsUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetUserTrendingPodcastsUseCase
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.testing.model.channelTestDataList
 import io.jacob.episodive.core.testing.model.episodeTestData
 import io.jacob.episodive.core.testing.model.episodeTestDataList
@@ -23,6 +24,8 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -164,8 +167,35 @@ class HomeViewModelTest {
         }
 
     @Test
-    fun `Given one flow throws, When collecting, Then state is Error`() = runTest {
-        every { getPlayingEpisodesUseCase(max = any()) } returns kotlinx.coroutines.flow.flow {
+    fun `Given one flow throws, When collecting, Then state is Error with Unexpected cause`() =
+        runTest {
+            every { getPlayingEpisodesUseCase(max = any()) } returns flow {
+                throw RuntimeException("Error")
+            }
+            every { getUserRecentPodcastsUseCase(max = any()) } returns flowOf(emptyList())
+            every { getMyRandomEpisodesUseCase(max = any()) } returns flowOf(emptyList())
+            every { getUserTrendingPodcastsUseCase(max = any()) } returns flowOf(emptyList())
+            every { getFollowedPodcastsUseCase(max = any()) } returns flowOf(emptyList())
+            every { getLocalTrendingPodcastsUseCase(max = any()) } returns flowOf(emptyList())
+            every { getForeignTrendingPodcastsUseCase(max = any()) } returns flowOf(emptyList())
+            every { getLiveEpisodesUseCase(max = any()) } returns flowOf(emptyList())
+            every { getChannelsUseCase() } returns flowOf(emptyList())
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is HomeState.Error)
+                // RuntimeException 은 DataErrorException 이 아니므로 asDataError() 가
+                // Unexpected 로 접어 올린다 — 판별 로직 자체는 core:model 쪽 책임이라 여기서는
+                // ViewModel 이 그 결과를 그대로 State 에 실었는지만 확인한다.
+                assertTrue((state as HomeState.Error).error is DataError.Unexpected)
+            }
+        }
+
+    @Test
+    fun `Given Retry action after failure, When sent, Then flows are resubscribed`() = runTest {
+        every { getPlayingEpisodesUseCase(max = any()) } returns flow {
             throw RuntimeException("Error")
         }
         every { getUserRecentPodcastsUseCase(max = any()) } returns flowOf(emptyList())
@@ -180,8 +210,17 @@ class HomeViewModelTest {
         val viewModel = createViewModel()
 
         viewModel.state.test {
-            val state = awaitItem()
-            assertTrue(state is HomeState.Error)
+            assertTrue(awaitItem() is HomeState.Error)
+
+            viewModel.sendAction(HomeAction.Retry)
+
+            // 재시도해도 같은 예외가 다시 나므로 State 는 여전히 Error 다. 다만 매번 새
+            // RuntimeException 인스턴스라 Throwable 의 기본 equals(참조 비교) 때문에 이전
+            // 값과 달라 StateFlow 가 재방출한다 — 그 자체가 flatMapLatest 가 실제로 재구독했다는
+            // 신호다. 값만으론 "같은 에러가 다시 온 것"과 "재시도가 아예 안 된 것"을 구분할 수
+            // 없으므로, combine 안의 소스 UseCase 호출 횟수로 재구독 여부를 명시적으로 검증한다.
+            assertTrue(awaitItem() is HomeState.Error)
+            verify(exactly = 2) { getPlayingEpisodesUseCase(max = any()) }
         }
     }
 

--- a/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryScreen.kt
@@ -65,6 +65,7 @@ import io.jacob.episodive.core.model.Category
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.SelectableCategory
+import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.core.ui.R as uiR
@@ -79,6 +80,7 @@ import io.jacob.episodive.core.ui.PodcastDetailItem
 import io.jacob.episodive.core.ui.PodcastDetailItemSkeleton
 import io.jacob.episodive.core.ui.PodcastsSection
 import io.jacob.episodive.core.ui.PodcastsSectionSkeleton
+import io.jacob.episodive.core.ui.asUiMessage
 import io.jacob.episodive.core.ui.displayName
 import io.jacob.episodive.core.ui.pagingAppendState
 import io.jacob.episodive.core.ui.pagingRefreshState
@@ -144,7 +146,15 @@ fun LibraryRoute(
             },
         )
 
-        is LibraryState.Error -> ErrorScreen(message = s.message)
+        is LibraryState.Error -> ErrorScreen(
+            message = s.error.asUiMessage(),
+            // 재시도해도 같은 결과가 오는 실패(없는 대상, 인증 실패)에는 버튼을 감춘다.
+            onRetry = if (s.error.isRetryable) {
+                { viewModel.sendAction(LibraryAction.Retry) }
+            } else {
+                null
+            },
+        )
     }
 }
 

--- a/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/io/jacob/episodive/feature/library/LibraryViewModel.kt
@@ -26,10 +26,12 @@ import io.jacob.episodive.core.domain.usecase.user.GetPreferredCategoriesUseCase
 import io.jacob.episodive.core.domain.usecase.user.GetSelectableCategoriesUseCase
 import io.jacob.episodive.core.domain.usecase.user.ToggleCategoryUseCase
 import io.jacob.episodive.core.model.Category
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.LibraryFindResult
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.SelectableCategory
+import io.jacob.episodive.core.model.asDataError
 import io.jacob.episodive.core.model.mapper.toHumanReadable
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -46,7 +48,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -84,6 +88,10 @@ class LibraryViewModel @Inject constructor(
         }
 
     private val _section = MutableStateFlow(LibrarySection.All)
+
+    // 재시도는 state 를 구성하는 소스 체인을 통째로 재구독해야 한다. 아래 소스들은 전부
+    // 재구독해도 부작용이 없는 것을 확인했다 (Paging 소스 3개는 이 체인과 분리돼 있어 대상이 아님).
+    private val retryTrigger = MutableStateFlow(0)
 
     val playedEpisodesPaging: Flow<PagingData<SeparatedUiModel<Episode>>> =
         getAllPlayedEpisodesPagingUseCase().map { pagingData ->
@@ -165,43 +173,45 @@ class LibraryViewModel @Inject constructor(
                 }
         }.cachedIn(viewModelScope)
 
-    val state: StateFlow<LibraryState> = combine(
-        _findQuery,
-        _findResult,
-        getAllPlayedEpisodesUseCase(max = SECTION_MAX),
-        getLikedEpisodesUseCase(max = SECTION_MAX),
-        getSavedEpisodesUseCase(max = SECTION_MAX),
-        getFollowedPodcastsUseCase(max = SECTION_MAX),
-        getPreferredCategoriesUseCase(),
-        getSelectableCategoriesUseCase(),
-        _section
-    ) { query, result, allPlayedEpisodes, likedEpisodes, savedEpisodes, followedPodcasts, preferredCategories, selectableCategories, section ->
-        if (query.isEmpty() && result.isAllEmpty) {
-            LibraryState.Success(
-                findQuery = query,
-                allPlayedEpisodes = allPlayedEpisodes,
-                likedEpisodes = likedEpisodes,
-                savedEpisodes = savedEpisodes,
-                followedPodcasts = followedPodcasts,
-                preferredCategories = preferredCategories,
-                selectableCategories = selectableCategories,
-                section = section,
-            ) as LibraryState
-        } else {
-            LibraryState.Success(
-                findQuery = query,
-                allPlayedEpisodes = result.playingEpisodes,
-                likedEpisodes = result.likedEpisodes,
-                savedEpisodes = result.savedEpisodes,
-                followedPodcasts = result.followedPodcasts,
-                preferredCategories = emptyList(),
-                selectableCategories = selectableCategories,
-                section = section,
-            ) as LibraryState
+    val state: StateFlow<LibraryState> = retryTrigger.flatMapLatest {
+        combine(
+            _findQuery,
+            _findResult,
+            getAllPlayedEpisodesUseCase(max = SECTION_MAX),
+            getLikedEpisodesUseCase(max = SECTION_MAX),
+            getSavedEpisodesUseCase(max = SECTION_MAX),
+            getFollowedPodcastsUseCase(max = SECTION_MAX),
+            getPreferredCategoriesUseCase(),
+            getSelectableCategoriesUseCase(),
+            _section
+        ) { query, result, allPlayedEpisodes, likedEpisodes, savedEpisodes, followedPodcasts, preferredCategories, selectableCategories, section ->
+            if (query.isEmpty() && result.isAllEmpty) {
+                LibraryState.Success(
+                    findQuery = query,
+                    allPlayedEpisodes = allPlayedEpisodes,
+                    likedEpisodes = likedEpisodes,
+                    savedEpisodes = savedEpisodes,
+                    followedPodcasts = followedPodcasts,
+                    preferredCategories = preferredCategories,
+                    selectableCategories = selectableCategories,
+                    section = section,
+                ) as LibraryState
+            } else {
+                LibraryState.Success(
+                    findQuery = query,
+                    allPlayedEpisodes = result.playingEpisodes,
+                    likedEpisodes = result.likedEpisodes,
+                    savedEpisodes = result.savedEpisodes,
+                    followedPodcasts = result.followedPodcasts,
+                    preferredCategories = emptyList(),
+                    selectableCategories = selectableCategories,
+                    section = section,
+                ) as LibraryState
+            }
+        }.catch { e ->
+            Timber.e(e, "보관함 데이터를 불러오지 못했다")
+            emit(LibraryState.Error(e.asDataError()))
         }
-    }.catch { e ->
-        emit(LibraryState.Error(e.message ?: "An unknown error occurred"))
-        e.printStackTrace()
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -231,6 +241,7 @@ class LibraryViewModel @Inject constructor(
                 is LibraryAction.ToggleFollowedPodcast -> toggleFollowedPodcast(action.podcast)
                 is LibraryAction.TogglePreferredCategory -> toggleCategory(action.category)
                 is LibraryAction.SelectSection -> selectSection(action.section)
+                is LibraryAction.Retry -> retry()
             }
         }
     }
@@ -286,6 +297,10 @@ class LibraryViewModel @Inject constructor(
         _section.emit(section)
     }
 
+    private fun retry() {
+        retryTrigger.update { it + 1 }
+    }
+
     companion object {
         private const val SECTION_MAX = 10
     }
@@ -304,7 +319,7 @@ sealed interface LibraryState {
         val section: LibrarySection,
     ) : LibraryState
 
-    data class Error(val message: String) : LibraryState
+    data class Error(val error: DataError) : LibraryState
 }
 
 sealed interface LibraryAction {
@@ -319,6 +334,7 @@ sealed interface LibraryAction {
     data class ToggleFollowedPodcast(val podcast: Podcast) : LibraryAction
     data class TogglePreferredCategory(val category: Category) : LibraryAction
     data class SelectSection(val section: LibrarySection) : LibraryAction
+    data object Retry : LibraryAction
 }
 
 sealed interface LibraryEffect {

--- a/feature/library/src/test/kotlin/io/jacob/episodive/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/kotlin/io/jacob/episodive/feature/library/LibraryViewModelTest.kt
@@ -19,6 +19,7 @@ import io.jacob.episodive.core.domain.usecase.user.GetPreferredCategoriesUseCase
 import io.jacob.episodive.core.domain.usecase.user.GetSelectableCategoriesUseCase
 import io.jacob.episodive.core.domain.usecase.user.ToggleCategoryUseCase
 import io.jacob.episodive.core.model.Category
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.LibraryFindResult
 import io.jacob.episodive.core.model.SelectableCategory
 import io.jacob.episodive.core.testing.model.episodeTestData
@@ -31,6 +32,7 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -164,9 +166,10 @@ class LibraryViewModelTest {
         }
 
     @Test
-    fun `Given flow throws, When collecting, Then state is Error`() = runTest {
+    fun `Given flow throws, When collecting, Then state is Error with Unexpected DataError`() = runTest {
+        val thrown = RuntimeException("Error")
         every { getAllPlayedEpisodesUseCase(max = any()) } returns kotlinx.coroutines.flow.flow {
-            throw RuntimeException("Error")
+            throw thrown
         }
         every { getLikedEpisodesUseCase(max = any()) } returns flowOf(emptyList())
         every { getSavedEpisodesUseCase(max = any()) } returns flowOf(emptyList())
@@ -179,8 +182,48 @@ class LibraryViewModelTest {
         viewModel.state.test {
             val state = awaitItem()
             assertTrue(state is LibraryState.Error)
+            // RuntimeException 은 DataErrorException 이 아니므로 Unexpected 로 떨어져야 한다.
+            // 참조 동일성은 비교하지 않는다 — 코루틴의 스택트레이스 복구가 코루틴 경계를 넘을 때
+            // 예외를 복제해 새 인스턴스를 만들기 때문에 메시지·타입만 확인한다.
+            val error = (state as LibraryState.Error).error
+            assertTrue(error is DataError.Unexpected)
+            assertEquals(thrown.message, (error as DataError.Unexpected).throwable?.message)
         }
     }
+
+    @Test
+    fun `Given error state, When Retry action is sent, Then sources are resubscribed and state recovers`() =
+        runTest {
+            every { getAllPlayedEpisodesUseCase(max = any()) } returns kotlinx.coroutines.flow.flow {
+                throw RuntimeException("Error")
+            }
+            every { getLikedEpisodesUseCase(max = any()) } returns flowOf(emptyList())
+            every { getSavedEpisodesUseCase(max = any()) } returns flowOf(emptyList())
+            every { getFollowedPodcastsUseCase(max = any()) } returns flowOf(emptyList())
+            every { getPreferredCategoriesUseCase() } returns flowOf(emptyList())
+            every { getSelectableCategoriesUseCase() } returns flowOf(emptyList())
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val errorState = awaitItem()
+                assertTrue(errorState is LibraryState.Error)
+
+                // 재시도 이후에는 정상 데이터가 오도록 스텁을 교체한다.
+                every { getAllPlayedEpisodesUseCase(max = any()) } returns flowOf(emptyList())
+
+                viewModel.sendAction(LibraryAction.Retry)
+                // _findResult 경로가 재구독되며 debounce(500L) 타이머가 다시 걸린다.
+                mainDispatcherRule.testDispatcher.scheduler.advanceTimeBy(600)
+
+                val state = awaitItem()
+                assertTrue(state is LibraryState.Success)
+            }
+
+            // 최초 구독 + Retry 로 인한 재구독, 총 2회 호출돼야 재시도가 실제로 소스를
+            // 다시 구독한다는 증거가 된다. 1회면 재시도가 캐시된 실패를 그대로 반환한 것.
+            verify(exactly = 2) { getAllPlayedEpisodesUseCase(max = any()) }
+        }
 
     @Test
     fun `Given ClickFind action, When sent, Then findQuery updates`() = runTest {

--- a/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingScreen.kt
@@ -79,10 +79,12 @@ import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Category
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.SelectableCategory
+import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.core.designsystem.component.EpisodiveFilterChip
 import io.jacob.episodive.core.ui.PodcastDetailItem
 import io.jacob.episodive.core.ui.PodcastDetailItemSkeleton
+import io.jacob.episodive.core.ui.asUiMessage
 import io.jacob.episodive.core.ui.displayName
 import io.jacob.episodive.core.ui.pagingAppendState
 import io.jacob.episodive.core.ui.pagingRefreshState
@@ -142,7 +144,14 @@ fun OnboardingRoute(
             onNextPage = { viewModel.sendAction(OnboardingAction.NextPage) },
         )
 
-        is OnboardingState.Error -> ErrorScreen(message = s.message)
+        is OnboardingState.Error -> ErrorScreen(
+            message = s.error.asUiMessage(),
+            onRetry = if (s.error.isRetryable) {
+                { viewModel.sendAction(OnboardingAction.Retry) }
+            } else {
+                null
+            },
+        )
     }
 }
 

--- a/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModel.kt
@@ -12,8 +12,10 @@ import io.jacob.episodive.core.domain.usecase.user.GetPreferredCategoriesUseCase
 import io.jacob.episodive.core.domain.usecase.user.SetFirstLaunchOffUseCase
 import io.jacob.episodive.core.domain.usecase.user.ToggleCategoryUseCase
 import io.jacob.episodive.core.model.Category
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.SelectableCategory
+import io.jacob.episodive.core.model.asDataError
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -64,22 +67,36 @@ class OnboardingViewModel @Inject constructor(
 
     // 팔로우 상태는 PagingData 를 무효화하지 않고 로컬 오버레이로만 반영한다.
     // (팔로우 토글이 리스트 전체를 refresh 시켜 스크롤이 튀는 문제 방지)
+    // state 와 별개의 stateIn 체인이라 실패해도 전체 화면을 Error 로 떨어뜨리지 않는다 — 대신
+    // 로그를 남기고 빈 집합으로 폴백해, 팟캐스트 선택 화면은 "전부 미팔로우"로만 보이게 한다.
     val followedPodcastIds: StateFlow<Set<Long>> =
         getFollowedPodcastsUseCase(max = Int.MAX_VALUE)
             .map { podcasts -> podcasts.map { it.id }.toSet() }
+            .catch { e ->
+                Timber.e(e, "Failed to load followed podcast ids")
+                emit(emptySet())
+            }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5000),
                 initialValue = emptySet(),
             )
 
-    val state: StateFlow<OnboardingState> = _categories.map { categories ->
-        OnboardingState.Success(
-            categories = categories,
-        ) as OnboardingState
-    }.catch { e ->
-        emit(OnboardingState.Error(e.message ?: "An unknown error occurred"))
-        e.printStackTrace()
+    // 재시도 액션이 들어오면 값을 증가시켜 아래 state 체인을 처음부터 다시 구독하게 한다.
+    private val retryTrigger = MutableStateFlow(0)
+
+    val state: StateFlow<OnboardingState> = retryTrigger.flatMapLatest {
+        // catch 를 flatMapLatest 안쪽(시도 1회 단위)에 둬야 한다. 바깥에 두면 예외를 잡은 뒤
+        // 전체 flow(retryTrigger 포함)가 완료돼 버려, 그 다음 retryTrigger 갱신이 와도 다시
+        // 구독을 시작할 수 없다 — retryTrigger 자체는 끝나지 않는 flow라 재시도가 먹통이 된다.
+        _categories.map { categories ->
+            OnboardingState.Success(
+                categories = categories,
+            ) as OnboardingState
+        }.catch { e ->
+            Timber.e(e, "온보딩 카테고리를 불러오지 못했다")
+            emit(OnboardingState.Error(e.asDataError()))
+        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -102,6 +119,7 @@ class OnboardingViewModel @Inject constructor(
                 is OnboardingAction.PreviousPage -> previousPage()
                 is OnboardingAction.ChooseCategory -> chooseCategory(action.category)
                 is OnboardingAction.ChoosePodcast -> choosePodcast(action.podcast)
+                is OnboardingAction.Retry -> retryTrigger.update { it + 1 }
             }
         }
     }
@@ -163,7 +181,7 @@ sealed interface OnboardingState {
         val categories: List<SelectableCategory>,
     ) : OnboardingState
 
-    data class Error(val message: String) : OnboardingState
+    data class Error(val error: DataError) : OnboardingState
 }
 
 sealed interface OnboardingAction {
@@ -171,6 +189,7 @@ sealed interface OnboardingAction {
     data object PreviousPage : OnboardingAction
     data class ChooseCategory(val category: Category) : OnboardingAction
     data class ChoosePodcast(val podcast: Podcast) : OnboardingAction
+    data object Retry : OnboardingAction
 }
 
 sealed interface OnboardingEffect {

--- a/feature/onboarding/src/test/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/kotlin/io/jacob/episodive/feature/onboarding/OnboardingViewModelTest.kt
@@ -9,6 +9,7 @@ import io.jacob.episodive.core.domain.usecase.user.GetPreferredCategoriesUseCase
 import io.jacob.episodive.core.domain.usecase.user.SetFirstLaunchOffUseCase
 import io.jacob.episodive.core.domain.usecase.user.ToggleCategoryUseCase
 import io.jacob.episodive.core.model.Category
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.testing.model.podcastTestData
 import io.jacob.episodive.core.testing.util.MainDispatcherRule
@@ -26,6 +27,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
 
 class OnboardingViewModelTest {
 
@@ -91,7 +93,7 @@ class OnboardingViewModelTest {
         }
 
     @Test
-    fun `Given categories flow throws, When collecting, Then state is Error`() = runTest {
+    fun `Given categories flow throws, When collecting, Then state is Error with Unexpected DataError`() = runTest {
         every { getPreferredCategoriesUseCase() } returns kotlinx.coroutines.flow.flow {
             throw RuntimeException("Error")
         }
@@ -102,8 +104,42 @@ class OnboardingViewModelTest {
         viewModel.state.test {
             val state = awaitItem()
             assertTrue(state is OnboardingState.Error)
+            // RuntimeException 은 DataErrorException 이 아니므로 Unexpected 로 떨어져야 한다.
+            assertTrue((state as OnboardingState.Error).error is DataError.Unexpected)
         }
     }
+
+    @Test
+    fun `Given state is Error, When Retry action sent, Then categories flow is resubscribed and recovers`() =
+        runTest {
+            // 첫 구독에서만 던지고 이후 구독부터는 성공하는 flow로 재구독 여부를 검증한다.
+            var collectCount = 0
+            every { getPreferredCategoriesUseCase() } returns kotlinx.coroutines.flow.flow {
+                collectCount++
+                if (collectCount == 1) {
+                    throw RuntimeException("Error")
+                } else {
+                    emit(emptyList())
+                }
+            }
+            every { getUserRecommendedPodcastsPagingUseCase(any()) } returns flowOf(PagingData.empty())
+
+            val viewModel = createViewModel()
+
+            // action -> handleActions -> retryTrigger 갱신 -> flatMapLatest 재구독 -> inner flow
+            // 재수집 -> state 방출까지 여러 홉을 거친다. runTest 안에서 Turbine 의 awaitItem() 은
+            // (가상 시간이 아닌) 실제 벽시계 기준 3초 기본 타임아웃을 쓰므로, 이 홉이 많은 체인은
+            // 머신이 바쁠 때 기본값을 넘기기 쉽다 — 로직 문제가 아니라 여유가 부족한 것이라
+            // 타임아웃만 넉넉히 늘린다.
+            viewModel.state.test(timeout = 10.seconds) {
+                assertTrue(awaitItem() is OnboardingState.Error)
+
+                viewModel.sendAction(OnboardingAction.Retry)
+
+                assertTrue(awaitItem() is OnboardingState.Success)
+            }
+            assertEquals(2, collectCount)
+        }
 
     @Test
     fun `Given Welcome page, When NextPage action sent, Then MoveToPage CategorySelection effect emitted`() =

--- a/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastScreen.kt
+++ b/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastScreen.kt
@@ -70,10 +70,12 @@ import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestData
 import io.jacob.episodive.core.ui.EpisodeItem
 import io.jacob.episodive.core.ui.EpisodeItemSkeleton
+import io.jacob.episodive.core.ui.asUiMessage
 import io.jacob.episodive.core.ui.pagingAppendState
 import io.jacob.episodive.core.ui.pagingRefreshState
 import kotlinx.coroutines.flow.Flow
@@ -140,7 +142,16 @@ internal fun PodcastRoute(
             )
         }
 
-        is PodcastState.Error -> ErrorScreen(message = s.message)
+        is PodcastState.Error -> ErrorScreen(
+            message = s.error.asUiMessage(),
+            // NotFound 는 재시도해도 결과가 같으므로 버튼을 감춘다 — 눌러도 아무 일이
+            // 없으면 앱이 고장 난 것처럼 보인다.
+            onRetry = if (s.error.isRetryable) {
+                { viewModel.sendAction(PodcastAction.Retry) }
+            } else {
+                null
+            },
+        )
     }
 }
 

--- a/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastViewModel.kt
+++ b/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastViewModel.kt
@@ -13,17 +13,23 @@ import io.jacob.episodive.core.domain.usecase.episode.ToggleLikedEpisodeUseCase
 import io.jacob.episodive.core.domain.usecase.player.PlayEpisodeUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetPodcastUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.ToggleFollowedUseCase
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.asDataError
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @HiltViewModel(assistedFactory = PodcastViewModel.Factory::class)
 class PodcastViewModel @AssistedInject constructor(
@@ -42,21 +48,27 @@ class PodcastViewModel @AssistedInject constructor(
 
     val episodesPaging = getEpisodesByPodcastIdPagingUseCase(id).cachedIn(viewModelScope)
 
-    val state: StateFlow<PodcastState> = getPodcastUseCase(id)
-        .map { podcast ->
-            podcast?.let {
-                PodcastState.Success(
-                    podcast = podcast,
-                )
-            } ?: PodcastState.Error("Podcast not found")
-        }.catch { e ->
-            emit(PodcastState.Error(e.message ?: "Unknown error"))
-            e.printStackTrace()
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = PodcastState.Loading
-        )
+    // 재시도는 소스 체인을 통째로 재구독해야 한다. getPodcastUseCase 는 콜드 Flow라
+    // 재구독해도 부작용이 없다.
+    private val retryTrigger = MutableStateFlow(0)
+
+    val state: StateFlow<PodcastState> = retryTrigger.flatMapLatest {
+        getPodcastUseCase(id)
+            .map { podcast ->
+                podcast?.let {
+                    PodcastState.Success(
+                        podcast = podcast,
+                    )
+                } ?: PodcastState.Error(DataError.NotFound)
+            }.catch { e ->
+                Timber.e(e, "팟캐스트 상세를 불러오지 못했다 (id=$id)")
+                emit(PodcastState.Error(e.asDataError()))
+            }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = PodcastState.Loading
+    )
 
     private val _action = MutableSharedFlow<PodcastAction>(extraBufferCapacity = 1)
 
@@ -74,6 +86,7 @@ class PodcastViewModel @AssistedInject constructor(
                 is PodcastAction.PlayEpisode -> playEpisode(action.episode, action.visibleEpisodes)
                 is PodcastAction.ToggleLikedEpisode -> toggleLikedEpisode(action.episode)
                 is PodcastAction.ToggleSavedEpisode -> toggleSavedEpisode(action.episode)
+                is PodcastAction.Retry -> retry()
             }
         }
     }
@@ -108,6 +121,10 @@ class PodcastViewModel @AssistedInject constructor(
             _effect.emit(PodcastEffect.ShowUnsaveSnackbar(episode))
         }
     }
+
+    private fun retry() {
+        retryTrigger.update { it + 1 }
+    }
 }
 
 sealed interface PodcastEffect {
@@ -121,7 +138,7 @@ sealed interface PodcastState {
         val podcast: Podcast,
     ) : PodcastState
 
-    data class Error(val message: String) : PodcastState
+    data class Error(val error: DataError) : PodcastState
 }
 
 sealed interface PodcastAction {
@@ -132,4 +149,5 @@ sealed interface PodcastAction {
     ) : PodcastAction
     data class ToggleLikedEpisode(val episode: Episode) : PodcastAction
     data class ToggleSavedEpisode(val episode: Episode) : PodcastAction
+    data object Retry : PodcastAction
 }

--- a/feature/podcast/src/test/kotlin/io/jacob/episodive/feature/podcast/PodcastViewModelTest.kt
+++ b/feature/podcast/src/test/kotlin/io/jacob/episodive/feature/podcast/PodcastViewModelTest.kt
@@ -8,6 +8,8 @@ import io.jacob.episodive.core.domain.usecase.episode.ToggleLikedEpisodeUseCase
 import io.jacob.episodive.core.domain.usecase.player.PlayEpisodeUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.GetPodcastUseCase
 import io.jacob.episodive.core.domain.usecase.podcast.ToggleFollowedUseCase
+import io.jacob.episodive.core.model.DataError
+import io.jacob.episodive.core.model.DataErrorException
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestData
@@ -80,7 +82,7 @@ class PodcastViewModelTest {
     }
 
     @Test
-    fun `Given null podcast, When flow emits, Then state is Error`() = runTest {
+    fun `Given null podcast, When flow emits, Then state is Error with NotFound`() = runTest {
         every { getPodcastUseCase(1L) } returns flowOf(null)
         every { getEpisodesByPodcastIdPagingUseCase(any()) } returns flowOf(PagingData.empty())
 
@@ -89,25 +91,68 @@ class PodcastViewModelTest {
         viewModel.state.test {
             val state = awaitItem()
             assertTrue(state is PodcastState.Error)
-            assertEquals("Podcast not found", (state as PodcastState.Error).message)
+            assertEquals(DataError.NotFound, (state as PodcastState.Error).error)
         }
     }
 
     @Test
-    fun `Given flow throws, When collecting, Then state is Error`() = runTest {
-        every { getPodcastUseCase(1L) } returns kotlinx.coroutines.flow.flow {
-            throw RuntimeException("Network error")
-        }
-        every { getEpisodesByPodcastIdPagingUseCase(any()) } returns flowOf(PagingData.empty())
+    fun `Given flow throws unrecognized exception, When collecting, Then state is Error with Unexpected`() =
+        runTest {
+            val exception = RuntimeException("Network error")
+            every { getPodcastUseCase(1L) } returns kotlinx.coroutines.flow.flow {
+                throw exception
+            }
+            every { getEpisodesByPodcastIdPagingUseCase(any()) } returns flowOf(PagingData.empty())
 
-        val viewModel = createViewModel()
+            val viewModel = createViewModel()
 
-        viewModel.state.test {
-            val state = awaitItem()
-            assertTrue(state is PodcastState.Error)
-            assertEquals("Network error", (state as PodcastState.Error).message)
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is PodcastState.Error)
+                val error = (state as PodcastState.Error).error
+                assertTrue(error is DataError.Unexpected)
+                assertEquals(exception, (error as DataError.Unexpected).throwable)
+            }
         }
-    }
+
+    @Test
+    fun `Given flow throws DataErrorException, When collecting, Then state is Error with the mapped DataError`() =
+        runTest {
+            every { getPodcastUseCase(1L) } returns kotlinx.coroutines.flow.flow {
+                throw DataErrorException(DataError.Offline)
+            }
+            every { getEpisodesByPodcastIdPagingUseCase(any()) } returns flowOf(PagingData.empty())
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is PodcastState.Error)
+                assertEquals(DataError.Offline, (state as PodcastState.Error).error)
+            }
+        }
+
+    @Test
+    fun `Given Retry action after error, When sent, Then getPodcastUseCase is resubscribed`() =
+        runTest {
+            var callCount = 0
+            every { getPodcastUseCase(1L) } answers {
+                callCount++
+                if (callCount == 1) flowOf(null) else flowOf(podcastTestData)
+            }
+            every { getEpisodesByPodcastIdPagingUseCase(any()) } returns flowOf(PagingData.empty())
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                assertTrue(awaitItem() is PodcastState.Error)
+
+                viewModel.sendAction(PodcastAction.Retry)
+
+                assertTrue(awaitItem() is PodcastState.Success)
+            }
+            assertEquals(2, callCount)
+        }
 
     @Test
     fun `Given ToggleFollowed action, When sent, Then toggleFollowedUseCase is invoked with id`() =

--- a/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/SearchScreen.kt
@@ -58,6 +58,7 @@ import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.RecentSearch
 import io.jacob.episodive.core.model.SearchResult
+import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.core.ui.EpisodeItem
@@ -65,6 +66,7 @@ import io.jacob.episodive.core.ui.EpisodesSection
 import io.jacob.episodive.core.ui.EpisodesSectionSkeleton
 import io.jacob.episodive.core.ui.PodcastsSection
 import io.jacob.episodive.core.ui.PodcastsSectionSkeleton
+import io.jacob.episodive.core.ui.asUiMessage
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -108,7 +110,16 @@ fun SearchRoute(
             )
         }
 
-        is SearchState.Error -> ErrorScreen(message = s.message)
+        is SearchState.Error -> ErrorScreen(
+            message = s.error.asUiMessage(),
+            // NotFound·Unauthorized 는 재시도해도 결과가 같으므로 버튼을 감춘다 — 눌러도
+            // 아무 일이 없으면 앱이 고장 난 것처럼 보인다.
+            onRetry = if (s.error.isRetryable) {
+                { viewModel.sendAction(SearchAction.Retry) }
+            } else {
+                null
+            },
+        )
     }
 }
 

--- a/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/SearchViewModel.kt
@@ -14,10 +14,12 @@ import io.jacob.episodive.core.domain.usecase.search.GetRecentSearchesUseCase
 import io.jacob.episodive.core.domain.usecase.search.SearchUseCase
 import io.jacob.episodive.core.domain.usecase.search.UpsertRecentSearchUseCase
 import io.jacob.episodive.core.model.Category
+import io.jacob.episodive.core.model.DataError
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.RecentSearch
 import io.jacob.episodive.core.model.SearchResult
+import io.jacob.episodive.core.model.asDataError
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -34,6 +36,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -65,24 +68,31 @@ class SearchViewModel @Inject constructor(
             }
         }
 
-    val state: StateFlow<SearchState> = combine(
-        _searchQuery,
-        _searchResult,
-        getRecentSearchesUseCase(RECENT_SEARCHES_LIMIT),
-        getRecentEpisodesUseCase(max = RECENT_EPISODES_MAX),
-        getTrendingPodcastsUseCase(max = TRENDING_PODCASTS_MAX),
-    ) { query, result, recentSearches, recentEpisodes, trendingPodcasts ->
-        SearchState.Success(
-            searchQuery = query,
-            searchResult = result,
-            recentSearches = recentSearches,
-            categories = Category.entries.toList(),
-            recentEpisodes = recentEpisodes,
-            trendingPodcasts = trendingPodcasts,
-        ) as SearchState
-    }.catch { e ->
-        emit(SearchState.Error(e.message ?: "An unknown error occurred"))
-        e.printStackTrace()
+    // 재시도는 소스 체인을 통째로 재구독해야 한다. 아래 5개 소스는 전부 콜드 Flow라 재구독해도
+    // 부작용이 없다. _searchResult 안에도 flatMapLatest 가 있지만 이 바깥의 flatMapLatest 는
+    // retry count 를 키로 쓰고 안쪽은 query 를 키로 쓰는, 서로 독립적인 체인이라 겹쳐도 문제없다.
+    private val retryTrigger = MutableStateFlow(0)
+
+    val state: StateFlow<SearchState> = retryTrigger.flatMapLatest {
+        combine(
+            _searchQuery,
+            _searchResult,
+            getRecentSearchesUseCase(RECENT_SEARCHES_LIMIT),
+            getRecentEpisodesUseCase(max = RECENT_EPISODES_MAX),
+            getTrendingPodcastsUseCase(max = TRENDING_PODCASTS_MAX),
+        ) { query, result, recentSearches, recentEpisodes, trendingPodcasts ->
+            SearchState.Success(
+                searchQuery = query,
+                searchResult = result,
+                recentSearches = recentSearches,
+                categories = Category.entries.toList(),
+                recentEpisodes = recentEpisodes,
+                trendingPodcasts = trendingPodcasts,
+            ) as SearchState
+        }.catch { e ->
+            Timber.e(e, "검색 화면 데이터를 불러오지 못했다")
+            emit(SearchState.Error(e.asDataError()))
+        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(60_000),
@@ -111,6 +121,7 @@ class SearchViewModel @Inject constructor(
                 is SearchAction.ClickPodcast -> clickPodcast(action.podcast)
                 is SearchAction.ClickEpisode -> clickEpisode(action.episode)
                 is SearchAction.ToggleLikedEpisode -> toggleLikedEpisode(action.episode)
+                is SearchAction.Retry -> retry()
             }
         }
     }
@@ -177,6 +188,10 @@ class SearchViewModel @Inject constructor(
         toggleLikedEpisodeUseCase(episode)
     }
 
+    private fun retry() {
+        retryTrigger.update { it + 1 }
+    }
+
     companion object {
         private const val SEARCH_MAX_RESULTS = 100
         private const val RECENT_SEARCHES_LIMIT = 100
@@ -196,7 +211,7 @@ sealed interface SearchState {
         val trendingPodcasts: List<Podcast>,
     ) : SearchState
 
-    data class Error(val message: String) : SearchState
+    data class Error(val error: DataError) : SearchState
 }
 
 sealed interface SearchAction {
@@ -210,6 +225,7 @@ sealed interface SearchAction {
     data class ClickPodcast(val podcast: Podcast) : SearchAction
     data class ClickEpisode(val episode: Episode) : SearchAction
     data class ToggleLikedEpisode(val episode: Episode) : SearchAction
+    data object Retry : SearchAction
 }
 
 sealed interface SearchEffect {

--- a/feature/search/src/test/kotlin/io/jacob/episodive/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/io/jacob/episodive/feature/search/SearchViewModelTest.kt
@@ -12,6 +12,8 @@ import io.jacob.episodive.core.domain.usecase.search.GetRecentSearchesUseCase
 import io.jacob.episodive.core.domain.usecase.search.SearchUseCase
 import io.jacob.episodive.core.domain.usecase.search.UpsertRecentSearchUseCase
 import io.jacob.episodive.core.model.Category
+import io.jacob.episodive.core.model.DataError
+import io.jacob.episodive.core.model.DataErrorException
 import io.jacob.episodive.core.model.RecentSearch
 import io.jacob.episodive.core.model.SearchResult
 import io.jacob.episodive.core.testing.model.episodeTestDataList
@@ -22,7 +24,9 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -115,18 +119,69 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `Given flow throws, When collecting, Then state is Error`() = runTest {
-        every { getRecentSearchesUseCase(any()) } returns kotlinx.coroutines.flow.flow {
-            throw RuntimeException("Error")
+    fun `Given flow throws unrecognized exception, When collecting, Then state is Error with Unexpected`() =
+        runTest {
+            val exception = RuntimeException("Error")
+            every { getRecentSearchesUseCase(any()) } returns kotlinx.coroutines.flow.flow {
+                throw exception
+            }
+            every { getRecentEpisodesUseCase(any()) } returns flowOf(emptyList())
+            every { getTrendingPodcastsUseCase(any()) } returns flowOf(emptyList())
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is SearchState.Error)
+                val error = (state as SearchState.Error).error
+                assertTrue(error is DataError.Unexpected)
+                // 코루틴이 flatMapLatest 경계를 넘으며 stacktrace 복구를 위해 RuntimeException을
+                // 복제해 참조 동일성이 깨진다 — message로만 비교한다.
+                assertEquals(exception.message, (error as DataError.Unexpected).throwable?.message)
+            }
         }
+
+    @Test
+    fun `Given flow throws DataErrorException, When collecting, Then state is Error with the mapped DataError`() =
+        runTest {
+            every { getRecentSearchesUseCase(any()) } returns kotlinx.coroutines.flow.flow {
+                throw DataErrorException(DataError.Offline)
+            }
+            every { getRecentEpisodesUseCase(any()) } returns flowOf(emptyList())
+            every { getTrendingPodcastsUseCase(any()) } returns flowOf(emptyList())
+
+            val viewModel = createViewModel()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state is SearchState.Error)
+                assertEquals(DataError.Offline, (state as SearchState.Error).error)
+            }
+        }
+
+    @Test
+    fun `Given Retry action, When sent, Then upstream flow chain is resubscribed`() = runTest {
+        every { getRecentSearchesUseCase(any()) } returns flowOf(emptyList())
         every { getRecentEpisodesUseCase(any()) } returns flowOf(emptyList())
         every { getTrendingPodcastsUseCase(any()) } returns flowOf(emptyList())
 
         val viewModel = createViewModel()
 
         viewModel.state.test {
-            val state = awaitItem()
-            assertTrue(state is SearchState.Error)
+            assertEquals(SearchState.Loading, awaitItem())
+            // Advance past debounce(500L) on _searchResult
+            mainDispatcherRule.testDispatcher.scheduler.advanceTimeBy(600)
+            assertTrue(awaitItem() is SearchState.Success)
+
+            viewModel.sendAction(SearchAction.Retry)
+            advanceUntilIdle()
+
+            // retryTrigger 가 바뀌면 flatMapLatest 가 상위 체인(getRecentSearchesUseCase 호출부터)을
+            // 통째로 재구독한다. Success 값 자체는 이전과 구조적으로 같아 StateFlow가 재방출을
+            // 걸러내므로, 두 번째 awaitItem() 대신 UseCase 호출 횟수로 재구독을 검증한다.
+            verify(exactly = 2) { getRecentSearchesUseCase(any()) }
+
+            cancelAndIgnoreRemainingEvents()
         }
     }
 


### PR DESCRIPTION
> #94 위에 쌓인 PR입니다. #94 를 먼저 머지해 주세요(머지 후 base 가 자동으로 `main` 으로 바뀝니다).

## 배경

느린 네트워크에서 홈을 열었더니 화면 한가운데 **`timeout`** 이라는 글자만 떠 있었습니다. 추적해 보니 세 층의 문제가 겹쳐 있었습니다.

## 변경 사항

### 1. 갱신에 실패해도 캐시가 있으면 계속 보여줍니다

`RemoteUpdater`가 `onStart { refreshIfNeeded() }`에서 예외를 그대로 던지고 있었습니다. **`onStart`에서 던진 예외는 Flow를 통째로 끊습니다.** 그래서 캐시 TTL이 지난 뒤 네트워크가 죽으면 Room에 데이터가 멀쩡히 있어도 화면에는 오류만 남았습니다. Offline-First를 표방하면서 실제로는 오프라인에서 아무것도 못 보던 셈입니다.

캐시가 있으면 갱신 실패를 삼키고 오래된 데이터라도 내보냅니다. 반대로 **캐시가 아예 없으면 그대로 올려** 화면이 오류를 다루게 합니다 — 캐시가 없을 때까지 삼키면 오류가 "데이터 없음"으로 둔갑합니다. 이 갈림이 핵심이라 양쪽 다 테스트로 고정했습니다.

이를 위해 `isExpired(): Boolean`을 `getOldestCachedAt(): Instant?`로 바꿨습니다. 만료 여부만 받으면 "캐시가 없다"와 "캐시가 오래됐다"를 가를 수 없는데, 둘은 실패했을 때 취할 행동이 정반대입니다. 덤으로 두 서브클래스에 중복돼 있던 TTL 비교가 기반 클래스로 모입니다.

### 2. 예외 메시지 대신 도메인 에러 타입

7개 ViewModel이 전부 `e.message`를 그대로 `State.Error`에 넣고 `ErrorScreen`이 그대로 출력하고 있었습니다. 현지화도 없고, 무엇을 해야 할지도 안 알려주고, HTTP 스택 내부가 새어 나옵니다.

`DataError`로 몇 갈래만 남깁니다. 더 잘게 쪼개지 않는 이유는 **사용자가 취할 행동이 같으면 같은 원인**이기 때문입니다 — 연결이 끊긴 것과 DNS가 실패한 것은 사용자에겐 똑같이 "네트워크를 확인하라"입니다. 판별은 네트워크 계층에서 한 번만 하고 결과를 실어 올립니다.

### 3. 재시도

`ErrorScreen`이 텍스트 하나뿐이라 앱 재시작 외에 복구 수단이 없었습니다. 재시도 버튼과 6개 화면의 `retryTrigger`를 추가합니다.

`isRetryable`이 false인 실패(없는 대상, 인증 실패)에는 버튼을 감춥니다 — 눌러도 아무 일이 없으면 앱이 고장 난 것처럼 보입니다.

**함정이 하나 있었습니다.** `.catch`를 `flatMapLatest` **바깥**에 두면 예외를 잡는 순간 파이프라인 전체가 정상 종료돼, 트리거를 아무리 밀어도 재구독이 일어나지 않습니다. 온보딩에서 실제로 밟고 테스트로 잡았습니다.

### 4. 네트워크 타임아웃 명시

`OkHttpClient`에 타임아웃 설정이 없어 기본값에 기대고 있었습니다. 각 단계 10초는 그렇다 쳐도 **`callTimeout`이 기본 무제한**이라, 단계마다 조금씩 진행되는 느린 연결에서는 어떤 타임아웃에도 걸리지 않고 무한히 기다릴 수 있었습니다.

### 덤: 채널의 도달 불가능한 코드

`channel`이 null일 때 `podcasts`가 `emptyFlow()`라 `combine`이 영영 값을 안 내보내, "찾을 수 없음" 분기에 **도달 자체가 불가능**했고 화면이 로딩에 멈춰 있었습니다. **기존 테스트가 그 상태를 정상인 양 고정**하고 있었습니다. 재시도를 붙이기 전에 먼저 고쳤습니다.

`printStackTrace()`도 Timber로 통일했습니다 — 레벨 없이 표준 출력으로 나가면 릴리스에서 아무 데도 안 남습니다.

## 테스트

- 6개 feature 모듈 197개 테스트 + `core:data` 전부 통과
- 신규: `RemoteUpdater` 실패 경로 6케이스(캐시 유지 / 캐시 없을 때 전파 / TTL 이내 스킵), 화면별 에러 매핑·재시도 재구독 검증
- 재시도 테스트는 mock 호출 횟수(`verify(exactly = 2)`)로 **실제 재구독이 일어났는지**까지 봅니다 — 상태값만 보면 "재시도 성공"과 "재시도가 아예 안 일어남"을 구분할 수 없습니다

**에뮬레이터 실기 확인**: 비행기 모드 + DB 비우고 콜드 스타트 → 오프라인 안내와 재시도 버튼 노출 → 비행기 모드 해제 후 버튼 클릭 → 홈 데이터 정상 로드.

## 손대지 않은 것

- **Player** — `ErrorScreen`을 아예 쓰지 않고, `Error`가 "재생 중인 것 없음"이라는 정상 상태와 뒤섞여 있습니다. 재시도 대상도 state 조합이 아니라 init의 1회성 복원 호출이라 같은 패턴이 옮겨지지 않습니다
- **Paging 스트림** — 보관함 4개 탭·팟캐스트 에피소드·온보딩 추천은 `state`와 분리된 경로라 `LazyPagingItems.retry()`를 쓰는 별도 트랙입니다
- **HTTP 200 안의 논리적 실패** — 응답의 `status`/`description`을 파싱만 하고 아무도 읽지 않아, API가 `status:"false"`로 알려주는 실패가 조용히 성공으로 취급됩니다
- **`ResponseListWrapper`** — 커스텀 deserializer가 `ResponseWrapper`에만 등록돼 있어 리스트 응답 구조가 어긋나면 무방비입니다
- **`NetworkMonitor`** — 이미 존재하지만 앱 UI에서만 쓰이고 데이터 계층엔 연결돼 있지 않습니다. 연결하면 사후 추론 대신 사전에 오프라인을 알 수 있습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLyAjZZ2GXfGcrEVAG8Qq9