### PR TITLE
fix: 앨범아트 로딩 실패를 조용히 한 번만

### DIFF
--- a/app/src/main/kotlin/io/jacob/episodive/sync/EpisodeSyncNotificationHelper.kt
+++ b/app/src/main/kotlin/io/jacob/episodive/sync/EpisodeSyncNotificationHelper.kt
@@ -14,6 +14,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.jacob.episodive.MainActivity
 import io.jacob.episodive.R
 import io.jacob.episodive.core.domain.usecase.episode.NewEpisodeResult
+import io.jacob.episodive.core.model.coverUrl
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -68,8 +69,9 @@ class EpisodeSyncNotificationHelper @Inject constructor(
 
         val latestEpisode = results.flatMap { it.episodes }
             .maxByOrNull { it.datePublished }
-        val largeIcon = latestEpisode?.image?.let { loadBitmap(it) }
-            ?: latestEpisode?.feedImage?.let { loadBitmap(it) }
+        // image 는 non-null String 이라 빈 문자열도 let 을 통과한다. 그대로 넘기면 실패가
+        // 뻔한 요청을 한 번 왕복시키므로 coverUrl 로 폴백을 마친 뒤 비어 있으면 아예 걷어낸다.
+        val largeIcon = latestEpisode?.coverUrl?.takeIf { it.isNotBlank() }?.let { loadBitmap(it) }
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.media3_notification_small_icon)

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/di/ImageModule.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/di/ImageModule.kt
@@ -1,6 +1,7 @@
 package io.jacob.episodive.core.data.di
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
@@ -11,6 +12,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.jacob.episodive.core.data.util.ImageCacheInterceptor
+import io.jacob.episodive.core.data.util.ImageFailureCache
+import io.jacob.episodive.core.data.util.ImageRequestInterceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -36,8 +39,10 @@ object ImageModule {
     fun provideImageLoader(
         @ApplicationContext context: Context,
         @ImageLoaderOkHttpClient okHttpClient: OkHttpClient,
+        imageFailureCache: ImageFailureCache,
     ): ImageLoader {
         return ImageLoader.Builder(context)
+            .components { add(ImageRequestInterceptor(imageFailureCache)) }
             .crossfade(true)
             .memoryCache {
                 MemoryCache.Builder(context)
@@ -51,7 +56,13 @@ object ImageModule {
                     .build()
             }
             .okHttpClient(okHttpClient)
-            .logger(DebugLogger())
+            .apply {
+                // DebugLogger 는 요청마다 로그를 쓴다. 릴리스 빌드에서는 순수한 낭비이고,
+                // 스크롤 한 번에 수십 줄이 쌓여 정작 봐야 할 로그를 덮는다.
+                if (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
+                    logger(DebugLogger())
+                }
+            }
             .build()
     }
 }

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/RecentSearchRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/repository/RecentSearchRepositoryImpl.kt
@@ -7,6 +7,7 @@ import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.RecentSearch
 import io.jacob.episodive.core.model.RecentSearchType
+import io.jacob.episodive.core.model.coverUrl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -37,7 +38,7 @@ class RecentSearchRepositoryImpl @Inject constructor(
                 type = RecentSearchType.PODCAST,
                 contentId = podcast.id,
                 title = podcast.title,
-                imageUrl = podcast.artwork.ifEmpty { podcast.image },
+                imageUrl = podcast.coverUrl,
                 subtitle = podcast.ownerName.ifEmpty { podcast.author },
                 searchedAt = Clock.System.now(),
             )
@@ -50,7 +51,7 @@ class RecentSearchRepositoryImpl @Inject constructor(
                 type = RecentSearchType.EPISODE,
                 contentId = episode.id,
                 title = episode.title,
-                imageUrl = episode.image.ifEmpty { episode.feedImage },
+                imageUrl = episode.coverUrl,
                 subtitle = episode.feedTitle ?: episode.feedAuthor ?: "",
                 searchedAt = Clock.System.now(),
             )

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageFailureCache.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageFailureCache.kt
@@ -1,0 +1,61 @@
+package io.jacob.episodive.core.data.util
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 최근 실패한 이미지 URL을 TTL 동안 기억해 같은 요청이 반복되는 것을 막는다.
+ *
+ * Coil은 실패를 캐시하지 않아서, 커버가 없는 항목은 스크롤로 화면을 드나들 때마다 매번 네트워크를
+ * 다시 탄다(실측: 같은 URL이 한 세션에 7회까지 재요청됐다). 결과는 늘 같은 실패인데 트래픽과 배터리만
+ * 쓴다.
+ *
+ * **메모리 전용이고 영속화하지 않는다.** 잘못 기록된 항목이 앱 재시작을 넘어 살아남으면 사용자가
+ * 취할 수 있는 유일한 복구 수단(앱을 다시 켜기)까지 막아버린다.
+ */
+@Singleton
+class ImageFailureCache internal constructor(
+    private val nowMs: () -> Long,
+) {
+    // Hilt 가 쓰는 생성자. 시계를 파라미터로 열어 두면 Dagger 가 Function0<Long> 바인딩을
+    // 찾으려 들기 때문에, 주입 경로와 테스트 경로를 생성자로 갈라 둔다.
+    @Inject
+    constructor() : this(System::currentTimeMillis)
+
+    private val entries = object : LinkedHashMap<String, Long>(INITIAL_CAPACITY, LOAD_FACTOR, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Long>) = size > MAX_ENTRIES
+    }
+
+    private val lock = Any()
+
+    /** [ttlMs] 동안 [url] 요청을 건너뛴다. */
+    fun record(url: String, ttlMs: Long) {
+        synchronized(lock) { entries[url] = nowMs() + ttlMs }
+    }
+
+    /** 아직 TTL이 남아 있으면 true. 만료된 항목은 조회하는 김에 걷어낸다. */
+    fun isBlocked(url: String): Boolean = synchronized(lock) {
+        val expiresAt = entries[url] ?: return false
+        if (nowMs() < expiresAt) return true
+        entries.remove(url)
+        false
+    }
+
+    /** 성공했으면 즉시 지운다 — 서버가 고쳐졌는데 TTL 때문에 계속 막는 일이 없도록. */
+    fun clear(url: String) {
+        synchronized(lock) { entries.remove(url) }
+    }
+
+    fun clear() {
+        synchronized(lock) { entries.clear() }
+    }
+
+    internal fun size(): Int = synchronized(lock) { entries.size }
+
+    private companion object {
+        // 한 화면에 뜨는 커버 수의 몇 배면 충분하다. 넘치면 오래된 것부터 버린다(LRU).
+        const val MAX_ENTRIES = 256
+        const val INITIAL_CAPACITY = 64
+        const val LOAD_FACTOR = 0.75f
+    }
+}

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageFailurePolicy.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageFailurePolicy.kt
@@ -1,0 +1,76 @@
+package io.jacob.episodive.core.data.util
+
+import coil.network.HttpException
+import java.io.InterruptedIOException
+import java.net.ConnectException
+import java.net.UnknownHostException
+import java.net.UnknownServiceException
+import java.security.cert.CertificateException
+import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLPeerUnverifiedException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * 이 실패를 기억해 둘 가치가 있는지, 있다면 얼마나인지 판정한다. null이면 기록하지 않는다.
+ *
+ * 기준은 `DataError.isRetryable` 과 같다 — **다시 시도하면 결과가 달라질 수 있는가.** 달라질 수
+ * 있는 실패(끊긴 네트워크, 타임아웃)를 기록하면 지하철에서 스크롤 한 번 한 것만으로 화면의 모든
+ * 커버가 블랙리스트에 올라간다. 그게 이 파일이 막아야 할 최악의 시나리오다.
+ *
+ * 모르는 실패는 기록하지 않는다. 놓친 재요청은 트래픽을 조금 쓰는 것으로 끝나지만, 잘못 기록한
+ * 항목은 멀쩡한 커버를 TTL 내내 가린다.
+ */
+fun Throwable.toImageFailureTtl(): Duration? = when (this) {
+    // 네트워크가 없거나 불안정한 것 — 앱 밖 사정이고 곧 바뀐다.
+    is UnknownHostException,
+    is ConnectException,
+    is InterruptedIOException, // SocketTimeoutException 포함
+        -> null
+
+    // cleartext 차단. 앱 설정이 바뀌기 전엔 절대 변하지 않는다.
+    is UnknownServiceException -> PERMANENT_TTL
+
+    // SSLHandshakeException 은 인증서 문제 전용이 아니다. 불안정한 망에서 핸드셰이크 도중
+    // 연결이 끊겨도 같은 예외가 온다("Connection reset by peer"). 그것까지 인증서로 보고
+    // 기록하면 지하철에서 스크롤 한 번에 화면의 커버가 전부 몇 시간씩 차단된다.
+    // OkHttp 의 RetryAndFollowUpInterceptor.isRecoverable() 과 같은 기준으로 갈라낸다 —
+    // 원인이 CertificateException 일 때만 진짜 인증서 문제다.
+    is SSLHandshakeException -> if (cause is CertificateException) CERTIFICATE_TTL else null
+
+    // 도메인 불일치는 전송 실패로 생기지 않는다.
+    is SSLPeerUnverifiedException,
+    is CertificateException,
+        -> CERTIFICATE_TTL
+
+    is HttpException -> when (response.code) {
+        // 504는 서버가 준 답이 아니라 OkHttp 가 만든 합성 응답인 경우가 있다.
+        // 오프라인에서 캐시에 없는 이미지를 요청하면 "Unsatisfiable Request (only-if-cached)"
+        // 로 이 코드가 온다(실기기 확인). 이걸 서버 오류로 기록하면 비행기 모드로 스크롤 한 번
+        // 한 것만으로 화면의 커버가 전부 차단되고, 네트워크가 돌아와도 TTL 동안 안 뜬다.
+        // 진짜 게이트웨이 타임아웃도 일시적이라 기록하지 않아 잃을 것이 없다.
+        HTTP_GATEWAY_TIMEOUT -> null
+        // 408도 4xx 지만 "다시 물어봐도 같은 답"의 정반대다. 부하 걸린 오리진이 한 번 뱉은
+        // 타임아웃 때문에 커버를 하루 종일 막을 이유가 없다.
+        HTTP_REQUEST_TIMEOUT -> null
+        // 과부하·레이트리밋은 곧 풀린다. 스크롤 한 번에 몰리는 재요청만 막으면 된다.
+        HTTP_TOO_MANY_REQUESTS -> TRANSIENT_TTL
+        in SERVER_ERROR_RANGE -> TRANSIENT_TTL
+        // 없는 파일, 핫링크 차단 — 다시 물어봐도 같은 답이 온다.
+        in CLIENT_ERROR_RANGE -> PERMANENT_TTL
+        else -> null
+    }
+
+    else -> null
+}
+
+private val PERMANENT_TTL = 24.hours
+private val CERTIFICATE_TTL = 6.hours
+private val TRANSIENT_TTL = 5.minutes
+
+private const val HTTP_REQUEST_TIMEOUT = 408
+private const val HTTP_TOO_MANY_REQUESTS = 429
+private const val HTTP_GATEWAY_TIMEOUT = 504
+private val CLIENT_ERROR_RANGE = 400..499
+private val SERVER_ERROR_RANGE = 500..599

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageRequestInterceptor.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageRequestInterceptor.kt
@@ -1,0 +1,72 @@
+package io.jacob.episodive.core.data.util
+
+import coil.intercept.Interceptor
+import coil.request.CachePolicy
+import coil.request.ErrorResult
+import coil.request.ImageResult
+import coil.request.SuccessResult
+import timber.log.Timber
+import java.io.IOException
+
+/**
+ * 이미지 요청이 엔진에 닿기 전에 세 가지를 처리한다.
+ *
+ * 1. 빈 URL을 걷어낸다 — 실패가 확정된 왕복을 아낀다.
+ * 2. 경로의 연속 슬래시를 접는다 — 서버에 따라 404가 되는 것을 살린다.
+ * 3. 최근 실패한 URL은 TTL 동안 네트워크를 잠근다.
+ *
+ * **OkHttp 인터셉터가 아니라 Coil 인터셉터인 이유**: 정규화를 OkHttp 단에서 하면 Coil의 캐시 키는
+ * 고치기 전 문자열로 계산되어, 같은 이미지가 두 번 캐싱되고 실패 기록도 두 갈래로 갈린다. 여기서
+ * `data` 를 바꾸면 캐시 키·실패 기록·실제 요청 URL이 한 번에 정렬된다.
+ */
+class ImageRequestInterceptor(
+    private val failureCache: ImageFailureCache,
+) : Interceptor {
+
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+        val request = chain.request
+        val data = request.data
+
+        // 문자열이 아닌 데이터(리소스 ID, Bitmap, File 등)는 이 인터셉터가 다룰 것이 없다.
+        if (data !is String) return chain.proceed(request)
+
+        if (data.isBlank()) {
+            return ErrorResult(request.error, request, BlankImageUrlException)
+        }
+
+        val normalized = normalizeImageUrl(data)
+        val blocked = failureCache.isBlocked(normalized)
+
+        val next = if (normalized == data && !blocked) {
+            request
+        } else {
+            request.newBuilder()
+                .data(normalized)
+                // 차단은 "네트워크를 타지 않는다"이지 "캐시된 그림도 안 쓴다"가 아니다. 요청을
+                // 여기서 끊어버리면 메모리·디스크 캐시 조회(EngineInterceptor 안에 있다)까지
+                // 건너뛰어, 방금까지 멀쩡히 보이던 커버가 TTL 동안 플레이스홀더로 바뀐다.
+                .apply { if (blocked) networkCachePolicy(CachePolicy.DISABLED) }
+                .build()
+        }
+
+        return chain.proceed(next).also { result ->
+            when (result) {
+                // 차단 중에 성공했다면 캐시가 받아준 것이지 서버가 고쳐진 것이 아니다.
+                // 그때 기록을 지우면 다음 요청이 다시 네트워크로 나가 같은 실패를 반복한다.
+                is SuccessResult -> if (!blocked) failureCache.clear(normalized)
+
+                is ErrorResult -> if (!blocked) {
+                    result.throwable.toImageFailureTtl()?.let { ttl ->
+                        failureCache.record(normalized, ttl.inWholeMilliseconds)
+                        // 로깅은 여기 한 곳에서만 한다. 차단된 요청은 이 분기로 오지 않으므로
+                        // 같은 URL이 로그를 도배하지 않고 자연스럽게 1회로 수렴한다.
+                        Timber.w("Image load failed ($ttl 동안 네트워크 잠금): $normalized — ${result.throwable}")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** URL이 비어 네트워크를 타지 않았다. */
+object BlankImageUrlException : IOException("이미지 URL이 비어 있다")

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageUrlNormalizer.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/util/ImageUrlNormalizer.kt
@@ -1,0 +1,33 @@
+package io.jacob.episodive.core.data.util
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/**
+ * 이미지 URL 경로의 연속 슬래시를 하나로 접는다.
+ *
+ * 피드가 주는 URL에 `http://host//images/a.jpg` 처럼 슬래시가 겹쳐 오는 경우가 있고, 서버에 따라
+ * 이걸 404로 돌려준다(실측: 겹치면 404, 접으면 200). 원인이 데이터 쪽이라 앱이 고칠 수 있는 몇 안 되는
+ * 실패다.
+ *
+ * 문자열을 정규식으로 훑지 않고 [okhttp3.HttpUrl] 로 파싱해 **경로 세그먼트만** 다룬다. 그래야
+ * 스킴의 `//`, 쿼리, 프래그먼트, 퍼센트 인코딩된 `%2F` 가 규칙이 아니라 타입으로 보호된다.
+ */
+fun normalizeImageUrl(raw: String): String {
+    // http(s) 가 아니면 손대지 않는다. content://, file://, 리소스 경로, 빈 문자열이 여기서 빠져나간다.
+    val url = raw.toHttpUrlOrNull() ?: return raw
+
+    val segments = url.encodedPathSegments
+
+    // 마지막 세그먼트가 비어 있는 것은 "/a/" 의 끝 슬래시이지 중복이 아니다. 그것까지 지우면
+    // 서버가 리다이렉트하거나 404를 내므로 판정 대상에서 뺀다.
+    if (segments.dropLast(1).none { it.isEmpty() }) return raw
+
+    val keepsTrailingSlash = segments.last().isEmpty()
+    val meaningful = segments.filter { it.isNotEmpty() }
+    val suffix = if (keepsTrailingSlash && meaningful.isNotEmpty()) "/" else ""
+
+    return url.newBuilder()
+        .encodedPath("/" + meaningful.joinToString("/") + suffix)
+        .build()
+        .toString()
+}

--- a/core/data/src/main/kotlin/io/jacob/episodive/core/data/widget/WidgetDataReaderImpl.kt
+++ b/core/data/src/main/kotlin/io/jacob/episodive/core/data/widget/WidgetDataReaderImpl.kt
@@ -11,6 +11,7 @@ import io.jacob.episodive.core.domain.usecase.podcast.GetUserRecentPodcastsUseCa
 import io.jacob.episodive.core.domain.widget.NowPlayingSnapshot
 import io.jacob.episodive.core.domain.widget.PodcastSnapshot
 import io.jacob.episodive.core.domain.widget.WidgetDataReader
+import io.jacob.episodive.core.model.coverUrl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -54,7 +55,7 @@ class WidgetDataReaderImpl @Inject constructor(
             title = episode.title,
             feedTitle = podcastName,
             // 에피소드 자체 image 가 비어있으면 feed(팟캐스트) 이미지로 fallback.
-            imageUrl = episode.image.ifBlank { episode.feedImage }.ifBlank { null },
+            imageUrl = episode.coverUrl.ifBlank { null },
             isPlaying = isPlaying,
         )
     }
@@ -73,7 +74,7 @@ class WidgetDataReaderImpl @Inject constructor(
                         podcastId = episode.feedId,
                         title = episode.title,
                         feedTitle = episode.feedTitle?.takeIf { it.isNotBlank() } ?: podcast?.title,
-                        imageUrl = episode.image.ifBlank { episode.feedImage }.ifBlank { null },
+                        imageUrl = episode.coverUrl.ifBlank { null },
                         isPlaying = active != null && isPlaying,
                     )
                 }
@@ -93,7 +94,7 @@ class WidgetDataReaderImpl @Inject constructor(
                     PodcastSnapshot(
                         id = podcast.id,
                         title = podcast.title,
-                        imageUrl = podcast.image.ifBlank { podcast.artwork }.ifBlank { null },
+                        imageUrl = podcast.coverUrl.ifBlank { null },
                     )
                 }
             }

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/model/CoverUrlTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/model/CoverUrlTest.kt
@@ -1,0 +1,93 @@
+package io.jacob.episodive.core.data.model
+
+import io.jacob.episodive.core.model.coverUrl
+import io.jacob.episodive.core.testing.model.episodeTestData
+import io.jacob.episodive.core.testing.model.podcastTestData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 커버 URL 폴백 규칙을 고정한다.
+ *
+ * 이 규칙이 흔들리면 화면마다 커버가 떴다 안 떴다 하므로, 순서를 바꾸는 변경은 여기서 먼저 걸린다.
+ */
+class CoverUrlTest {
+
+    @Test
+    fun `Given podcast with image, when coverUrl read, then returns image`() {
+        // Given
+        val podcast = podcastTestData.copy(
+            image = "https://example.com/image.jpg",
+            artwork = "https://example.com/artwork.jpg",
+        )
+
+        // When & Then
+        assertEquals("https://example.com/image.jpg", podcast.coverUrl)
+    }
+
+    @Test
+    fun `Given podcast with blank image, when coverUrl read, then falls back to artwork`() {
+        // Given
+        val podcast = podcastTestData.copy(
+            image = "",
+            artwork = "https://example.com/artwork.jpg",
+        )
+
+        // When & Then
+        assertEquals("https://example.com/artwork.jpg", podcast.coverUrl)
+    }
+
+    @Test
+    fun `Given podcast with both blank, when coverUrl read, then returns blank`() {
+        // Given
+        val podcast = podcastTestData.copy(image = "", artwork = "")
+
+        // When & Then
+        assertEquals("", podcast.coverUrl)
+    }
+
+    @Test
+    fun `Given episode with image, when coverUrl read, then returns image`() {
+        // Given
+        val episode = episodeTestData.copy(
+            image = "https://example.com/episode.jpg",
+            feedImage = "https://example.com/feed.jpg",
+        )
+
+        // When & Then
+        assertEquals("https://example.com/episode.jpg", episode.coverUrl)
+    }
+
+    @Test
+    fun `Given episode with blank image, when coverUrl read, then falls back to feedImage`() {
+        // Given
+        val episode = episodeTestData.copy(
+            image = "",
+            feedImage = "https://example.com/feed.jpg",
+        )
+
+        // When & Then
+        assertEquals("https://example.com/feed.jpg", episode.coverUrl)
+    }
+
+    @Test
+    fun `Given episode with both blank, when coverUrl read, then returns blank`() {
+        // Given
+        val episode = episodeTestData.copy(image = "", feedImage = "")
+
+        // When & Then
+        assertEquals("", episode.coverUrl)
+    }
+
+    @Test
+    fun `Given whitespace only image, when coverUrl read, then treats as blank`() {
+        // Given — API 가 공백만 있는 문자열을 주는 경우가 있어 isEmpty 가 아니라 isBlank 로 판정한다
+        val episode = episodeTestData.copy(
+            image = "   ",
+            feedImage = "https://example.com/feed.jpg",
+        )
+
+        // When & Then
+        assertEquals("https://example.com/feed.jpg", episode.coverUrl)
+    }
+}

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageFailureCacheTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageFailureCacheTest.kt
@@ -1,0 +1,94 @@
+package io.jacob.episodive.core.data.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageFailureCacheTest {
+
+    private var now = 0L
+    private val cache = ImageFailureCache { now }
+
+    @Test
+    fun `Given unrecorded url, when checked, then not blocked`() {
+        assertFalse(cache.isBlocked("https://example.com/a.jpg"))
+    }
+
+    @Test
+    fun `Given recorded url, when checked within ttl, then blocked`() {
+        // Given
+        cache.record(URL, ttlMs = 1_000)
+
+        // When
+        now = 999
+
+        // Then
+        assertTrue(cache.isBlocked(URL))
+    }
+
+    @Test
+    fun `Given recorded url, when ttl expired, then not blocked`() {
+        // Given
+        cache.record(URL, ttlMs = 1_000)
+
+        // When
+        now = 1_000
+
+        // Then
+        assertFalse(cache.isBlocked(URL))
+    }
+
+    @Test
+    fun `Given expired entry, when checked, then evicted`() {
+        // Given
+        cache.record(URL, ttlMs = 1_000)
+        now = 2_000
+
+        // When
+        cache.isBlocked(URL)
+
+        // Then — 만료된 항목이 자리를 계속 차지하지 않는다
+        assertEquals(0, cache.size())
+    }
+
+    @Test
+    fun `Given recorded url, when cleared, then not blocked`() {
+        // Given
+        cache.record(URL, ttlMs = 10_000)
+
+        // When
+        cache.clear(URL)
+
+        // Then — 서버가 고쳐졌는데 TTL 때문에 계속 막히면 안 된다
+        assertFalse(cache.isBlocked(URL))
+    }
+
+    @Test
+    fun `Given entries beyond capacity, when recorded, then oldest evicted`() {
+        // Given & When
+        repeat(300) { cache.record("https://example.com/$it.jpg", ttlMs = 10_000) }
+
+        // Then
+        assertEquals(256, cache.size())
+        assertFalse(cache.isBlocked("https://example.com/0.jpg"))
+        assertTrue(cache.isBlocked("https://example.com/299.jpg"))
+    }
+
+    @Test
+    fun `Given concurrent records, when done, then stays within capacity`() {
+        // Given & When
+        val threads = List(8) { t ->
+            Thread { repeat(100) { cache.record("https://example.com/$t-$it.jpg", ttlMs = 10_000) } }
+        }
+        threads.forEach(Thread::start)
+        threads.forEach(Thread::join)
+
+        // Then — 인터셉터는 여러 스레드에서 동시에 돈다
+        assertEquals(256, cache.size())
+    }
+
+    private companion object {
+        const val URL = "https://example.com/a.jpg"
+    }
+}

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageFailurePolicyTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageFailurePolicyTest.kt
@@ -1,0 +1,112 @@
+package io.jacob.episodive.core.data.util
+
+import coil.network.HttpException
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.net.UnknownServiceException
+import java.security.cert.CertificateExpiredException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * 어떤 실패를 기억하고 어떤 실패를 잊을지 고정한다.
+ *
+ * 가장 중요한 테스트는 "기록하지 않는다"쪽이다. 일시적 실패를 기록하면 지하철에서 스크롤 한 번에
+ * 화면 전체가 블랙리스트로 굳는다.
+ */
+class ImageFailurePolicyTest {
+
+    @Test
+    fun `Given offline errors, when policy applied, then not recorded`() {
+        assertNull(UnknownHostException("no dns").toImageFailureTtl())
+        assertNull(ConnectException("refused").toImageFailureTtl())
+        assertNull(SocketTimeoutException("timeout").toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given not found, when policy applied, then recorded for a day`() {
+        assertEquals(24.hours, httpException(404).toImageFailureTtl())
+        assertEquals(24.hours, httpException(410).toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given hotlink block, when policy applied, then recorded for a day`() {
+        assertEquals(24.hours, httpException(403).toImageFailureTtl())
+        assertEquals(24.hours, httpException(401).toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given server error, when policy applied, then recorded briefly`() {
+        assertEquals(5.minutes, httpException(500).toImageFailureTtl())
+        assertEquals(5.minutes, httpException(503).toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given unsatisfiable request, when policy applied, then not recorded`() {
+        // 504 는 서버 응답이 아니라 OkHttp 가 오프라인 캐시 미스에 만드는 합성 응답으로도 온다
+        // ("Unsatisfiable Request (only-if-cached)", 실기기 확인). 이걸 기록하면 비행기 모드로
+        // 스크롤 한 번에 화면 전체가 차단된다.
+        assertNull(httpException(504).toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given rate limited, when policy applied, then recorded briefly`() {
+        // 429 는 4xx 지만 곧 풀리므로 영구 취급하면 안 된다.
+        assertEquals(5.minutes, httpException(429).toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given request timeout, when policy applied, then not recorded`() {
+        // 408 은 4xx 지만 "다시 물어봐도 같은 답"의 정반대다.
+        assertNull(httpException(408).toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given certificate failure, when policy applied, then recorded for hours`() {
+        val handshake = SSLHandshakeException("bad cert").apply {
+            initCause(CertificateExpiredException("expired"))
+        }
+
+        assertEquals(6.hours, handshake.toImageFailureTtl())
+        assertEquals(6.hours, CertificateExpiredException("expired").toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given handshake interrupted by network, when policy applied, then not recorded`() {
+        // SSLHandshakeException 은 인증서 문제 전용이 아니다. 불안정한 망에서 핸드셰이크 도중
+        // 연결이 끊겨도 같은 예외가 온다. 그것까지 기록하면 지하철에서 스크롤 한 번에 화면의
+        // 커버가 전부 몇 시간씩 차단된다.
+        val transport = SSLHandshakeException("Connection reset by peer")
+
+        assertNull(transport.toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given cleartext blocked, when policy applied, then recorded for a day`() {
+        assertEquals(24.hours, UnknownServiceException("cleartext not permitted").toImageFailureTtl())
+    }
+
+    @Test
+    fun `Given unknown error, when policy applied, then not recorded`() {
+        // 모르는 실패는 기록하지 않는다 — 놓친 재요청보다 잘못된 차단이 나쁘다.
+        assertNull(IllegalStateException("???").toImageFailureTtl())
+        assertNull(RuntimeException().toImageFailureTtl())
+    }
+
+    private fun httpException(code: Int) = HttpException(
+        Response.Builder()
+            .request(Request.Builder().url("https://example.com/a.jpg").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("test")
+            .build()
+    )
+}

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageRequestInterceptorTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageRequestInterceptorTest.kt
@@ -1,0 +1,195 @@
+package io.jacob.episodive.core.data.util
+
+import android.content.Context
+import android.graphics.drawable.ColorDrawable
+import androidx.test.core.app.ApplicationProvider
+import coil.decode.DataSource
+import coil.intercept.Interceptor
+import coil.network.HttpException
+import coil.request.CachePolicy
+import coil.request.ErrorResult
+import coil.request.ImageRequest
+import coil.request.ImageResult
+import coil.request.SuccessResult
+import coil.size.Size
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.net.UnknownHostException
+
+@RunWith(RobolectricTestRunner::class)
+class ImageRequestInterceptorTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private var now = 0L
+    private val cache = ImageFailureCache { now }
+    private val interceptor = ImageRequestInterceptor(cache)
+
+    @Test
+    fun `Given blank url, when intercepted, then never reaches engine`() = runTest {
+        // Given
+        val chain = chain(request(""), success())
+
+        // When
+        val result = interceptor.intercept(chain)
+
+        // Then
+        coVerify(exactly = 0) { chain.proceed(any()) }
+        assertTrue(result is ErrorResult)
+    }
+
+    @Test
+    fun `Given doubled slash, when intercepted, then proceeds with normalized url`() = runTest {
+        // Given
+        val chain = chain(request("https://example.com//images/a.jpg"), success())
+        val forwarded = slot<ImageRequest>()
+
+        // When
+        interceptor.intercept(chain)
+
+        // Then
+        coVerify { chain.proceed(capture(forwarded)) }
+        assertEquals("https://example.com/images/a.jpg", forwarded.captured.data)
+    }
+
+    @Test
+    fun `Given permanent failure recorded, when requested again, then network is disabled`() = runTest {
+        // Given — 404 는 다시 물어봐도 같은 답이 온다
+        val first = chain(request(URL), error(httpException(404)))
+        interceptor.intercept(first)
+
+        // When
+        val second = chain(request(URL), success())
+        val forwarded = slot<ImageRequest>()
+        interceptor.intercept(second)
+
+        // Then — 요청을 끊지 않고 네트워크만 잠근다. 캐시에 그림이 있으면 그건 써야 한다.
+        coVerify { second.proceed(capture(forwarded)) }
+        assertEquals(CachePolicy.DISABLED, forwarded.captured.networkCachePolicy)
+    }
+
+    @Test
+    fun `Given blocked request served from cache, when succeeded, then record is kept`() = runTest {
+        // Given
+        interceptor.intercept(chain(request(URL), error(httpException(404))))
+
+        // When — 차단 중 캐시가 받아준다
+        interceptor.intercept(chain(request(URL), success()))
+
+        // Then — 캐시 히트일 뿐 서버가 고쳐진 게 아니므로 잠금이 유지돼야 한다
+        val third = chain(request(URL), success())
+        val forwarded = slot<ImageRequest>()
+        interceptor.intercept(third)
+
+        coVerify { third.proceed(capture(forwarded)) }
+        assertEquals(CachePolicy.DISABLED, forwarded.captured.networkCachePolicy)
+    }
+
+    @Test
+    fun `Given offline failure, when requested again, then still reaches engine`() = runTest {
+        // Given — 이 테스트가 깨지면 지하철에서 화면 전체가 블랙리스트로 굳는다
+        val first = chain(request(URL), error(UnknownHostException("no dns")))
+        interceptor.intercept(first)
+
+        // When
+        val second = chain(request(URL), success())
+        val result = interceptor.intercept(second)
+
+        // Then
+        coVerify(exactly = 1) { second.proceed(any()) }
+        assertTrue(result is SuccessResult)
+    }
+
+    @Test
+    fun `Given ttl expired, when requested again, then network is enabled again`() = runTest {
+        // Given
+        interceptor.intercept(chain(request(URL), error(httpException(500))))
+
+        // When — 5분 뒤
+        now = 5 * 60 * 1000L
+        val second = chain(request(URL), success())
+        val forwarded = slot<ImageRequest>()
+        interceptor.intercept(second)
+
+        // Then
+        coVerify { second.proceed(capture(forwarded)) }
+        assertEquals(CachePolicy.ENABLED, forwarded.captured.networkCachePolicy)
+    }
+
+    @Test
+    fun `Given recorded failure, when it later succeeds over network, then record is dropped`() = runTest {
+        // Given
+        interceptor.intercept(chain(request(URL), error(httpException(500))))
+        now = 5 * 60 * 1000L
+
+        // When — TTL 이 지나 네트워크로 성공했다
+        interceptor.intercept(chain(request(URL), success()))
+
+        // Then — 기록이 지워져 다음 요청도 네트워크를 쓸 수 있어야 한다
+        now = 6 * 60 * 1000L
+        val third = chain(request(URL), success())
+        val forwarded = slot<ImageRequest>()
+        interceptor.intercept(third)
+
+        coVerify { third.proceed(capture(forwarded)) }
+        assertEquals(CachePolicy.ENABLED, forwarded.captured.networkCachePolicy)
+    }
+
+    @Test
+    fun `Given non string data, when intercepted, then passes through untouched`() = runTest {
+        // Given — 리소스 ID 처럼 URL 이 아닌 데이터는 이 인터셉터가 다룰 것이 없다
+        val chain = chain(request(RESOURCE_ID), success())
+
+        // When
+        val result = interceptor.intercept(chain)
+
+        // Then
+        coVerify(exactly = 1) { chain.proceed(any()) }
+        assertTrue(result is SuccessResult)
+    }
+
+    private fun request(data: Any) = ImageRequest.Builder(context).data(data).build()
+
+    private fun chain(request: ImageRequest, result: ImageResult): Interceptor.Chain = mockk {
+        every { this@mockk.request } returns request
+        every { size } returns Size.ORIGINAL
+        coEvery { proceed(any()) } returns result
+    }
+
+    private fun success() = SuccessResult(
+        drawable = ColorDrawable(),
+        request = request(URL),
+        dataSource = DataSource.NETWORK,
+    )
+
+    private fun error(throwable: Throwable) = ErrorResult(
+        drawable = null,
+        request = request(URL),
+        throwable = throwable,
+    )
+
+    private fun httpException(code: Int) = HttpException(
+        Response.Builder()
+            .request(Request.Builder().url(URL).build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("test")
+            .build()
+    )
+
+    private companion object {
+        const val URL = "https://example.com/a.jpg"
+        const val RESOURCE_ID = 12345
+    }
+}

--- a/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageUrlNormalizerTest.kt
+++ b/core/data/src/test/kotlin/io/jacob/episodive/core/data/util/ImageUrlNormalizerTest.kt
@@ -1,0 +1,94 @@
+package io.jacob.episodive.core.data.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 정규화가 고쳐야 할 것만 고치고 나머지는 건드리지 않는지 고정한다.
+ *
+ * 이 함수의 위험은 "404를 못 고치는 것"이 아니라 "멀쩡한 URL을 깨뜨리는 것"이므로,
+ * 불변이어야 하는 케이스를 고치는 케이스보다 많이 둔다.
+ */
+class ImageUrlNormalizerTest {
+
+    @Test
+    fun `Given doubled slash in path, when normalized, then collapses to one`() {
+        assertEquals(
+            "http://graphics.nytimes.com/images/apps/podcasts/w750/theethicist.jpg",
+            normalizeImageUrl("http://graphics.nytimes.com//images/apps/podcasts/w750/theethicist.jpg"),
+        )
+    }
+
+    @Test
+    fun `Given multiple doubled slashes, when normalized, then collapses all`() {
+        assertEquals("https://h/a/b/c.png", normalizeImageUrl("https://h/a//b//c.png"))
+    }
+
+    @Test
+    fun `Given tripled slash, when normalized, then collapses to one`() {
+        assertEquals("https://h/a/b.png", normalizeImageUrl("https://h/a///b.png"))
+    }
+
+    @Test
+    fun `Given trailing slash, when normalized, then keeps it`() {
+        // 끝 슬래시를 지우면 서버가 리다이렉트하거나 404를 낸다. 중복이 아니라 의미다.
+        assertEquals("https://h/a/", normalizeImageUrl("https://h/a/"))
+    }
+
+    @Test
+    fun `Given doubled slash with trailing slash, when normalized, then collapses but keeps trailing`() {
+        assertEquals("https://h/a/b/", normalizeImageUrl("https://h/a//b/"))
+    }
+
+    @Test
+    fun `Given root path only, when normalized, then unchanged`() {
+        assertEquals("https://h/", normalizeImageUrl("https://h/"))
+    }
+
+    @Test
+    fun `Given normal url, when normalized, then unchanged`() {
+        assertEquals("https://h/a/b.jpg", normalizeImageUrl("https://h/a/b.jpg"))
+    }
+
+    @Test
+    fun `Given doubled slash in query, when normalized, then query untouched`() {
+        assertEquals("https://h/a/b.jpg?x=//y", normalizeImageUrl("https://h/a/b.jpg?x=//y"))
+    }
+
+    @Test
+    fun `Given doubled slash in fragment, when normalized, then fragment untouched`() {
+        assertEquals("https://h/a/b.jpg#f//g", normalizeImageUrl("https://h/a/b.jpg#f//g"))
+    }
+
+    @Test
+    fun `Given percent encoded slashes, when normalized, then untouched`() {
+        // %2F 는 경로 구분자가 아니라 파일명의 일부다. 접으면 다른 파일을 가리킨다.
+        assertEquals("https://h/a%2F%2Fb.jpg", normalizeImageUrl("https://h/a%2F%2Fb.jpg"))
+    }
+
+    @Test
+    fun `Given path fixed with query present, when normalized, then query preserved`() {
+        assertEquals(
+            "https://h/images/a.jpg?aid=rss_feed",
+            normalizeImageUrl("https://h//images/a.jpg?aid=rss_feed"),
+        )
+    }
+
+    @Test
+    fun `Given non http scheme, when normalized, then returned as is`() {
+        assertEquals("content://media/1", normalizeImageUrl("content://media/1"))
+        assertEquals("file:///x//y", normalizeImageUrl("file:///x//y"))
+        assertEquals("android.resource://pkg/123", normalizeImageUrl("android.resource://pkg/123"))
+    }
+
+    @Test
+    fun `Given blank input, when normalized, then returned as is`() {
+        assertEquals("", normalizeImageUrl(""))
+        assertEquals("   ", normalizeImageUrl("   "))
+    }
+
+    @Test
+    fun `Given userinfo and port, when normalized, then preserved`() {
+        assertEquals("https://user:pw@h:8443/a", normalizeImageUrl("https://user:pw@h:8443//a"))
+    }
+}

--- a/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/component/Image.kt
+++ b/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/component/Image.kt
@@ -5,11 +5,11 @@ import androidx.annotation.Px
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,18 +20,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
-import io.jacob.episodive.core.designsystem.icon.EpisodiveIcons
 import io.jacob.episodive.core.designsystem.theme.EpisodiveTheme
 import io.jacob.episodive.core.designsystem.tooling.ThemePreviews
-import timber.log.Timber
 import kotlin.math.abs
 
 @Composable
@@ -40,9 +42,11 @@ fun StateImage(
     imageUrl: String,
     @Px size: Int = 300,
     contentDescription: String?,
+    // 커버를 못 그릴 때 대신 얹을 머리글자의 출처. 호출부는 거의 항상 contentDescription 에
+    // 제목을 넘기므로 그것을 기본값으로 재사용한다. 제목이 아닌 설명을 넘기는 곳만 직접 지정하면 된다.
+    title: String? = contentDescription,
     contentScale: ContentScale = ContentScale.Crop,
     placeholderBrush: Brush = thumbnailPlaceholderDefaultBrush(imageUrl),
-    fallbackIcon: ImageVector = EpisodiveIcons.Error,
     // 색 추출 규칙(필터·휘도 클램프)은 전부 EpisodiveDominantColor 가 갖는다.
     // 화면마다 보정값을 따로 주면 같은 커버에서 화면마다 다른 색이 나오므로 여기서 열지 않는다.
     onDominantColorExtracted: ((Color) -> Unit)? = null,
@@ -50,6 +54,15 @@ fun StateImage(
 ) {
     if (LocalInspectionMode.current) {
         Box(modifier = modifier.background(placeholderBrush))
+        return
+    }
+
+    // 커버가 아예 없는 항목이 드물지 않다(에피소드 절반 이상이 자체 이미지가 없다). 빈 URL 을
+    // 그대로 Coil 에 넘기면 실패할 요청을 한 번 왕복시키고 나서야 같은 자리에 같은 면을 그린다.
+    if (imageUrl.isBlank()) {
+        Box(modifier = modifier) {
+            CoverPlaceholder(placeholderBrush, title, contentDescription)
+        }
         return
     }
 
@@ -93,34 +106,19 @@ fun StateImage(
         contentAlignment = Alignment.Center
     ) {
         when (imagePainterState) {
+            // 실패를 로딩과 같은 면으로 그린다. 관측된 실패는 전부 서버 쪽 결함(만료 인증서,
+            // 핫링크 403, 없는 파일)이라 사용자가 취할 행동이 없는데, 목록에 경고 아이콘이
+            // 흩뿌려지면 앱이 고장난 것처럼 읽힌다. 머리글자를 얹은 정지된 면은 "커버가 없는
+            // 팟캐스트"로 자연스럽게 읽히고, 그게 실제로 일어난 일에 더 가깝다.
             is AsyncImagePainter.State.Empty,
             is AsyncImagePainter.State.Loading,
+            is AsyncImagePainter.State.Error,
                 -> {
                 // 여기에 shimmer 를 넣지 않는다. 스켈레톤 카드가 사라지고 실제 카드가 뜬 직후
                 // 이미지는 아직 로딩 중인 경우가 많아 "끝난 줄 알았는데 또 반짝"이 되고,
                 // 스크롤 중에는 늘 몇 장이 로딩 중이라 목록이 상시 명멸한다. 정지된 면으로 둔다.
-                Box(
-                    modifier = Modifier
-                        .background(placeholderBrush)
-                        .fillMaxSize()
-                )
-            }
-
-            is AsyncImagePainter.State.Error,
-                -> {
-                Timber.w("Image($imageUrl) load error: ${(imagePainterState as? AsyncImagePainter.State.Error)?.result?.throwable.toString()}")
-                Box(
-                    modifier = Modifier
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                        .fillMaxSize()
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .padding(8.dp),
-                        imageVector = fallbackIcon,
-                        contentDescription = null,
-                    )
-                }
+                // contentDescription 은 아래 Image 가 들고 있으므로 여기서는 넘기지 않는다.
+                CoverPlaceholder(placeholderBrush, title, contentDescription = null)
             }
 
             is AsyncImagePainter.State.Success -> {
@@ -141,6 +139,53 @@ fun StateImage(
         )
     }
 }
+
+/**
+ * 커버를 그릴 수 없을 때 자리를 지키는 면 — 로딩 중, URL 없음, 로드 실패 셋 모두 여기로 온다.
+ * 제목 머리글자를 얹어 "아직 안 온 빈 칸"이 아니라 "원래 이렇게 생긴 커버"로 읽히게 한다.
+ */
+@Composable
+private fun CoverPlaceholder(
+    brush: Brush,
+    title: String?,
+    contentDescription: String?,
+) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .background(brush)
+            .fillMaxSize()
+            // 이 분기에는 Image 가 없어 설명을 붙일 노드가 사라진다. 그대로 두면 TalkBack 이
+            // 제목 대신 머리글자 한 글자만 읽는다.
+            .semantics { contentDescription?.let { this.contentDescription = it } },
+        contentAlignment = Alignment.Center,
+    ) {
+        // 부모가 무한 제약을 주면 side 가 Dp.Infinity 가 되어 폰트 크기가 발산한다.
+        val side = minOf(maxWidth, maxHeight).coerceAtMost(CoverInitialMaxSide)
+        val initial = title?.coverInitial()
+
+        // 작은 썸네일에서는 글자가 뭉개져 노이즈만 된다. 그럴 땐 면만 남긴다.
+        if (initial != null && side >= CoverInitialMinSide) {
+            Text(
+                text = initial,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = CoverInitialAlpha),
+                fontSize = with(LocalDensity.current) { (side * CoverInitialSideRatio).toSp() },
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                // 머리글자는 장식이다. 위에서 붙인 설명과 겹쳐 읽히지 않게 가린다.
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+        }
+    }
+}
+
+/** 제목의 첫 글자. 이모지나 문장부호로 시작하는 제목은 글자를 포기하고 면만 남긴다. */
+private fun String.coverInitial(): String? =
+    trim().firstOrNull()?.takeIf(Char::isLetterOrDigit)?.uppercase()
+
+private val CoverInitialMinSide = 40.dp
+private val CoverInitialMaxSide = 240.dp
+private const val CoverInitialSideRatio = 0.38f
+private const val CoverInitialAlpha = 0.55f
 
 private const val ImageCrossfadeMs = 200
 

--- a/core/model/src/main/kotlin/io/jacob/episodive/core/model/CoverUrl.kt
+++ b/core/model/src/main/kotlin/io/jacob/episodive/core/model/CoverUrl.kt
@@ -1,0 +1,21 @@
+package io.jacob.episodive.core.model
+
+/**
+ * 커버 아트 URL을 고르는 단일 규칙.
+ *
+ * 예전에는 화면마다 폴백이 제각각이었다 — 어떤 곳은 `artwork`를 먼저 보고, 어떤 곳은 `image`를
+ * 먼저 보고, 목록 카드는 아예 폴백 없이 `image`만 봤다. 그래서 `image`가 비고 `artwork`만 있는
+ * 팟캐스트의 커버가 화면에 따라 떴다 안 떴다 했다.
+ *
+ * `image`를 앞에 두는 이유: Podcast Index 응답에서 `artwork`만 있고 `image`가 빈 경우는 실측상
+ * 없었고 그 반대는 있었다. 순서를 뒤집으면 실익 없이 기존 캐시 키만 전부 갈린다.
+ */
+val Podcast.coverUrl: String
+    get() = image.ifBlank { artwork }
+
+/**
+ * 에피소드는 자체 이미지가 없는 쪽이 오히려 흔하다(피드가 에피소드별 아트를 주지 않는다).
+ * 그때는 피드 커버로 대신한다. 둘 다 비면 빈 문자열이고, 그건 StateImage 가 플레이스홀더로 받는다.
+ */
+val Episode.coverUrl: String
+    get() = image.ifBlank { feedImage }

--- a/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
+++ b/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
@@ -14,6 +14,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import io.jacob.episodive.core.domain.download.EpisodeDownloader
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Progress
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.mapper.toDurationMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -169,7 +170,8 @@ class PlayerDataSourceImpl @Inject constructor(
             .setDisplayTitle(title)
             .setSubtitle(feedTitle)
             .setDescription(description)
-            .setArtworkUri(image.ifEmpty { feedImage }.toUri())
+            // 빈 문자열을 넘기면 빈 Uri 가 그대로 들어가 잠금화면이 아트를 로드하려다 실패한다.
+            .setArtworkUri(coverUrl.ifBlank { null }?.toUri())
             .build()
 
         // 다운로드 완료 판정은 DB 상태가 아니라 실제 파일 존재로 한다.

--- a/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Episode.kt
+++ b/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Episode.kt
@@ -79,6 +79,7 @@ import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.designsystem.tooling.ThemePreviews
 import io.jacob.episodive.core.model.Episode
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.mapper.toHumanReadable
 import io.jacob.episodive.core.model.mapper.toIntSeconds
 import io.jacob.episodive.core.model.mapper.toRelativeDate
@@ -365,7 +366,7 @@ fun EpisodeItem(
             modifier = Modifier
                 .size(dimension.thumbnailSmall)
                 .clip(MaterialTheme.shapes.medium),
-            imageUrl = episode.image.ifEmpty { episode.feedImage },
+            imageUrl = episode.coverUrl,
             contentDescription = episode.title,
         )
 
@@ -566,7 +567,7 @@ fun PlayingEpisodeItem(
                 modifier = Modifier
                     .size(68.dp)
                     .clip(EpisodiveShapes.coverForSize(68)),
-                imageUrl = playedEpisode.image.ifEmpty { playedEpisode.feedImage },
+                imageUrl = playedEpisode.coverUrl,
                 contentDescription = playedEpisode.title,
             )
 
@@ -635,7 +636,7 @@ fun PlayedEpisodeItem(
             modifier = Modifier
                 .size(dimension.thumbnailMedium)
                 .clip(EpisodiveShapes.miniPlayer),
-            imageUrl = playedEpisode.image.ifEmpty { playedEpisode.feedImage },
+            imageUrl = playedEpisode.coverUrl,
             contentDescription = playedEpisode.title,
         )
 
@@ -790,7 +791,7 @@ fun EpisodeDetailItem(
             modifier = Modifier
                 .size(200.dp)
                 .clip(MaterialTheme.shapes.large),
-            imageUrl = episode.image.ifEmpty { episode.feedImage },
+            imageUrl = episode.coverUrl,
             contentDescription = episode.title,
         )
 
@@ -888,8 +889,11 @@ fun EpisodeClipItem(
             modifier = Modifier
                 .fillMaxSize()
                 .blur(radius = 20.dp),
-            imageUrl = episode.image.ifEmpty { episode.feedImage },
+            imageUrl = episode.coverUrl,
             contentDescription = episode.title,
+            // 이건 카드 뒤에 깔리는 블러 배경이다. 커버가 없을 때 머리글자까지 얹으면
+            // 화면 폭만 한 글자가 흐리게 번져 앞의 커버와 겹친다.
+            title = null,
         )
 
         Box(
@@ -918,7 +922,7 @@ fun EpisodeClipItem(
                 StateImage(
                     modifier = Modifier
                         .fillMaxSize(),
-                    imageUrl = episode.image.ifEmpty { episode.feedImage },
+                    imageUrl = episode.coverUrl,
                     contentDescription = episode.title,
                     // 화면 배경 그라디언트를 이 커버 색으로 물들이기 위해 위로 올린다.
                     onDominantColorExtracted = onDominantColorExtracted,

--- a/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Podcast.kt
+++ b/core/ui/src/main/kotlin/io/jacob/episodive/core/ui/Podcast.kt
@@ -52,6 +52,7 @@ import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.designsystem.tooling.ThemePreviews
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.mapper.toHumanReadable
 import io.jacob.episodive.core.testing.model.podcastTestData
 import io.jacob.episodive.core.testing.model.podcastTestDataList
@@ -170,7 +171,7 @@ fun PodcastItem(
                 .fillMaxWidth()
                 .aspectRatio(1f)
                 .clip(MaterialTheme.shapes.large),
-            imageUrl = podcast.image,
+            imageUrl = podcast.coverUrl,
             contentDescription = podcast.title,
         )
 
@@ -284,7 +285,7 @@ fun PodcastDetailItem(
             modifier = Modifier
                 .size(DetailItemCoverSize)
                 .clip(EpisodiveShapes.coverForSize(96)),
-            imageUrl = podcast.image,
+            imageUrl = podcast.coverUrl,
             contentDescription = podcast.title,
         )
 
@@ -511,7 +512,7 @@ fun PodcastSimpleItem(
             modifier = Modifier
                 .size(50.dp)
                 .clip(EpisodiveShapes.field),
-            imageUrl = podcast.image,
+            imageUrl = podcast.coverUrl,
             contentDescription = podcast.title,
         )
 

--- a/feature/channel/src/main/kotlin/io/jacob/episodive/feature/channel/ChannelScreen.kt
+++ b/feature/channel/src/main/kotlin/io/jacob/episodive/feature/channel/ChannelScreen.kt
@@ -60,6 +60,7 @@ import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Channel
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.channelTestData
 import io.jacob.episodive.core.testing.model.podcastTestDataList
@@ -387,7 +388,7 @@ private fun ChannelPodcastCard(
                 .fillMaxWidth()
                 .aspectRatio(1f)
                 .clip(MaterialTheme.shapes.medium),
-            imageUrl = podcast.image,
+            imageUrl = podcast.coverUrl,
             contentDescription = podcast.title,
             onDominantColorExtracted = { backgroundColor = it },
         )

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
@@ -74,6 +74,7 @@ import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Channel
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.model.mapper.toHumanReadable
 import io.jacob.episodive.core.testing.model.channelTestDataList
@@ -492,7 +493,7 @@ private fun HomeContinueListeningHero(
                     modifier = Modifier
                         .size(HomeHeroCoverSize)
                         .clip(EpisodiveShapes.coverForSize(HomeHeroCoverSizeDp)),
-                    imageUrl = episode.image.ifEmpty { episode.feedImage },
+                    imageUrl = episode.coverUrl,
                     contentDescription = episode.title,
                     // 카드 그라디언트를 이 커버 색으로 물들이기 위해 위로 올린다.
                     onDominantColorExtracted = { dominantColor = it },

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerBar.kt
@@ -52,6 +52,7 @@ import io.jacob.episodive.core.model.Chapter
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.Progress
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.testing.model.episodeTestData
 import io.jacob.episodive.core.testing.model.podcastTestData
 import io.jacob.episodive.core.ui.R as uiR
@@ -229,7 +230,7 @@ internal fun PlayerBarContent(
                     modifier = Modifier
                         .size(42.dp)
                         .clip(RoundedCornerShape(11.dp)),
-                    imageUrl = nowPlaying.image.ifEmpty { nowPlaying.feedImage },
+                    imageUrl = nowPlaying.coverUrl,
                     contentDescription = nowPlaying.title,
                     onDominantColorExtracted = { dominantColor = it },
                 )

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
@@ -99,6 +99,7 @@ import io.jacob.episodive.core.model.Chapter
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
 import io.jacob.episodive.core.model.Progress
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.mapper.toHumanReadable
 import io.jacob.episodive.core.model.mapper.toLongMillis
 import io.jacob.episodive.core.model.mapper.toMediaTime
@@ -407,7 +408,7 @@ internal fun PlayerScreen(
                                 .fillMaxSize()
                                 .clip(EpisodiveShapes.playerCover),
                             size = 600,
-                            imageUrl = nowPlaying.image.ifEmpty { nowPlaying.feedImage },
+                            imageUrl = nowPlaying.coverUrl,
                             contentDescription = nowPlaying.title,
                             onDominantColorExtracted = { dominantColor = it },
                         )

--- a/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastScreen.kt
+++ b/feature/podcast/src/main/kotlin/io/jacob/episodive/feature/podcast/PodcastScreen.kt
@@ -70,6 +70,7 @@ import io.jacob.episodive.core.designsystem.theme.LocalDimensionTheme
 import io.jacob.episodive.core.designsystem.tooling.DevicePreviews
 import io.jacob.episodive.core.model.Episode
 import io.jacob.episodive.core.model.Podcast
+import io.jacob.episodive.core.model.coverUrl
 import io.jacob.episodive.core.model.isRetryable
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestData
@@ -552,7 +553,7 @@ private fun PodcastHeader(
                     spotColor = Color.Black.copy(alpha = 0.7f),
                 )
                 .clip(shape = EpisodiveShapes.heroCover),
-            imageUrl = podcast.image,
+            imageUrl = podcast.coverUrl,
             contentDescription = podcast.title,
             onDominantColorExtracted = onDominantColorExtracted,
         )


### PR DESCRIPTION
## 변경 사항

실행 중인 앱 logcat에서 커버 아트 로딩 실패를 확인하고 원인을 실측했습니다. **대부분 서버 측 결함이라 앱이 고칠 수 없었고**, 정작 앱의 문제는 따로 있었습니다 — 실패한 URL을 스크롤·리컴포지션마다 다시 요청하고 있었습니다(같은 URL이 한 세션에 7회·4회·2회).

목표를 "실패를 없애는 것"이 아니라 **빨리, 조용히, 한 번만 실패하는 것**으로 잡았습니다.

### 실측한 원인

| 실패 | 원인 | 조치 |
|:--|:--|:--|
| `HTTP 404` — `graphics.nytimes.com//images/…` | 경로 더블 슬래시 (`//` → 404, `/` → 200, curl 확인) | 정규화로 **해결** |
| `SSLHandshakeException` — `m.imtpod.com` | 인증서 만료 + CN이 `strategicts.net`으로 불일치 | 서버 결함 → 조용히 실패 |
| `HTTP 403` — `i.namu.wiki` | 핫링크 차단 (UA·Referer 변경 모두 403) | 서버 정책 → 조용히 실패 |

### 구현

- **커버 URL 규칙 통일** (`core/model/CoverUrl.kt`) — 기존엔 세 갈래로 갈려 있었고 `core/ui/Podcast.kt`는 `artwork` 폴백이 아예 없어 뜰 수 있는 커버를 놓쳤습니다. DB 실측상 `artwork`만 있고 `image`가 빈 행은 0개, 반대는 2개라 `image` 우선으로 통일했습니다.
- **URL 경로 정규화** (`ImageUrlNormalizer.kt`) — 정규식이 아니라 `okhttp3.HttpUrl` 파싱으로 경로 세그먼트만 다뤄, 쿼리·`%2F`·후행 슬래시가 규칙이 아니라 타입으로 보호됩니다.
- **실패 캐싱** (`ImageFailureCache.kt`, `ImageFailurePolicy.kt`, `ImageRequestInterceptor.kt`) — 최근 실패 URL의 **네트워크만** TTL 동안 잠급니다. 캐시에 그림이 있으면 그건 씁니다.
- **실패 UI** (`Image.kt`) — 경고 아이콘 대신 그라디언트 + 제목 머리글자. 관측된 실패가 전부 서버 결함이라 사용자가 취할 행동이 없는데, 목록에 경고가 흩뿌려지면 앱이 고장난 것처럼 읽힙니다.
- **빈 URL 가드** — 에피소드 이미지의 57%(1351/2354행)가 빈 문자열입니다.
- **로그 정리** — 컴포지션 본문에서 매 리컴포지션마다 돌던 `Timber.w` 제거, `DebugLogger`를 디버그 빌드로 한정.

### 기록 정책 — 설계의 핵심

`DataError.isRetryable`과 같은 기준(**다시 시도하면 결과가 달라질 수 있는가**)을 적용했습니다.

| 실패 | 기록 | TTL |
|:--|:--:|:--|
| 404 / 410 / 401 / 403 | O | 24h |
| 인증서 문제 (`cause is CertificateException`) | O | 6h |
| cleartext 차단 | O | 24h |
| 5xx (504 제외) / 429 | O | 5m |
| 오프라인 · 타임아웃 · 408 · 504 · 전송 계층 TLS 실패 | **X** | — |
| 그 외 | **X** | — |

일시적 실패를 기록하면 지하철에서 스크롤 한 번에 화면 전체가 굳습니다. 모르는 실패는 기록하지 않습니다.

## 테스트

**전체 1,076개 통과 (실패 0)**, 신규 51개.

`ImageUrlNormalizerTest`(14) · `ImageFailurePolicyTest`(11) · `ImageRequestInterceptorTest`(8) · `ImageFailureCacheTest`(7) · `CoverUrlTest`(7)

정규화 테스트는 "고치는 케이스"보다 **"불변이어야 하는 케이스"를 더 많이** 뒀습니다. 이 함수의 위험은 404를 못 고치는 게 아니라 멀쩡한 URL을 깨뜨리는 것이기 때문입니다.

### 실기기 검증에서 잡은 버그 두 개

유닛 테스트를 다 통과시킨 뒤 에뮬레이터(Pixel_9_Pro)에서 확인하다 잡았습니다.

1. **오프라인이 `HTTP 504 Unsatisfiable Request (only-if-cached)`로 위장** — OkHttp가 캐시 미스에 만드는 합성 응답인데, 정책이 이를 5xx 서버 오류로 보고 5분간 기록했습니다. 막으려던 회귀 그 자체라 504를 제외하고 테스트로 고정했습니다.
2. **코드리뷰가 잡은 `SSLHandshakeException` 오분류** — 이 예외는 인증서 전용이 아니고 불안정한 망에서 핸드셰이크가 끊겨도 발생합니다. OkHttp의 `RetryAndFollowUpInterceptor.isRecoverable()`과 같은 기준(`cause is CertificateException`)으로 갈랐습니다.

### 최종 실기기 결과 (스크롤 12회)

- negative cache 기록: **URL당 1회**
- 실패 URL로 나간 실제 OkHttp 요청: **0건**
- 기내 모드 on → off 후 이미지 정상 재로드 (오프라인이 블랙리스트로 굳지 않음)

## 하지 않은 것

`ImageCacheInterceptor`의 http→https 강제 전환은 **그대로 뒀습니다.** 이 때문에 `183.111.158.118`(IP 리터럴, https 연결 불가)의 커버가 실패하지만 DB 전체에서 **1개**입니다. `network_security_config.xml`에 IP를 추가해 살리는 선택지는 기각했습니다 — IP 리터럴에는 DNS/레지스트라의 소유 보증이 없어 재할당 이후에도 영구 평문 채널이 열린 채 배포되고, 평문 이미지는 경로상 공격자가 인프로세스 디코더에 임의 바이트를 주입할 수 있는 표면입니다. 커버 1장의 대가로 치를 값이 아닙니다.

인증서 검증 우회(`TrustManager` 무력화, `HostnameVerifier` 우회, Referer 위조)도 하지 않았습니다.

## 알려진 한계

- 잠금화면 앨범아트는 Media3가 자체 HTTP 스택(`DataSourceBitmapLoader`)을 쓰므로 정규화·실패 캐시가 적용되지 않습니다. 이번엔 `coverUrl` 통일과 빈 값 가드만 했습니다.
- 경로에 빈 세그먼트가 의미를 갖는 URL(S3 키, 경로 서명 CDN)은 정규화가 깨뜨릴 수 있습니다. 현재 피드 데이터에는 **0건**이라 방어를 넣지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DLsxHwqXt44iH1dRNAC4S