### PR TITLE
docs: 구현 체크리스트 최신화 및 재편

### DIFF
--- a/docs/IMPLEMENTATION_CHECKLIST.md
+++ b/docs/IMPLEMENTATION_CHECKLIST.md
@@ -1,161 +1,239 @@
 # 구현 체크리스트
 
-이 문서는 Episodive 앱의 기능 구현 상태를 추적하기 위한 체크리스트입니다.
+Episodive의 기능 구현 상태를 추적합니다.
 
-## 온보딩
+**마지막 검증**: `1aef969` (2026-08-04) — 전 항목을 코드에 대조해 갱신했습니다.
 
-- ✅ 앱 소개
-- ✅ 권한 요청
-- ✅ 선호 카테고리 선택 (2열 x행)
-- ✅ 선호 팟캐스트 구독 선택 (vertical)
-    - /recent/feeds (lang, cat)
+| 표기 | 의미 |
+|:--:|:----|
+| ✅ | 구현됨 — UI 노출부터 데이터 계층까지 경로가 연결됨 |
+| 🟡 | 부분 구현 — 일부만 동작하거나 UI에 노출되지 않음 (사유를 함께 기재) |
+| ⬜ | 미구현 |
 
-## 메인 화면
+> 갱신 규칙: 기능을 추가·변경한 PR은 이 문서의 해당 항목도 함께 고칩니다.
+> 판정이 애매한 항목에는 근거(`파일:줄` 또는 PR 번호)를 남겨 재감사 비용을 줄입니다.
 
-Navigation 4개 탭:
+---
 
-- 홈
-- 검색
-- 라이브러리
-- 클립
+## 1. 사용자 여정
 
-### 홈
+### 1.1 온보딩
 
-- ✅ 최근 재생 에피소드 이어듣기 리스트 (horizontal)
-- ✅ 선호 최근 팟캐스트 리스트 (horizontal)
-    - /recent/feeds (lang, cat)
-- ✅ 랜덤 에피소드 리스트 (vertical 6)
-    - /episodes/random (lang, cat)
-- ✅ 선호 인기 팟캐스트 리스트 (horizontal)
-    - /podcasts/trending (lang, cat)
-- ✅ 구독 팟캐스트 리스트 (horizontal)
-- ✅ 지역 인기 팟캐스트 리스트 (horizontal)
-    - /podcasts/trending (lang)
-- ✅ 해외 인기 팟캐스트 리스트 (horizontal)
-    - /podcasts/trending (lang)
-- ✅ 라이브 에피소드 리스트 (vertical)
-    - /episodes/live
-- ✅ 채널 리스트 (horizontal)
-    - db, /search/byterm
-    - CNN, 뇌부자들, JTBC, BBC, ...
+- ✅ 앱 소개 (Welcome 페이지)
+- ✅ 선호 카테고리 선택 — FlowRow + FilterChip, 한글 표시명 112종 (#72, #91)
+- ✅ 선호 팟캐스트 팔로우 선택 (vertical)
+    - `/podcasts/trending` + `/recent/feeds` 병렬 호출 병합 (Recommended)
+    - ✅ 팔로우 토글 시 리스트 리로드·스크롤 튐 없음 (#80)
+- ✅ 완료 화면 — 지연 후 홈 자동 진입
 
-### 검색
+> 권한 요청은 온보딩 단계가 아니라 앱 콜드스타트 시점에 일어납니다 → [2.4](#24-딥링크--권한) 참조.
 
-- ✅ 검색창
-    - /search/byterm (q, max)
-    - /episodes/byfeedid (id, max)
-    - 결과:
-        - ✅ 검색 히스토리 (vertical)
-        - ✅ 검색 팟캐스트 리스트 (vertical)
-        - ✅ 검색 에피소드 리스트 (vertical)
-- ⬜ 카테고리 리스트 (horizontal)
-- ✅ 최근 에피소드 리스트 (horizontal)
-    - /recent/episodes
-    - 상세:
-        - ⬜ 최근 팟캐스트 리스트 (horizontal)
-            - /recent/feeds
-        - ⬜ 최근 에피소드 리스트 (vertical)
-            - /recent/episodes
-- ⬜ 인기 팟캐스트 리스트 (vertical)
-    - /podcasts/trending
-    - 상세:
-        - Global, Korean, Categories, ... chips
+### 1.2 홈
 
-### 라이브러리
+- ✅ 최근 재생 에피소드 이어듣기 (horizontal)
+- ✅ 선호 최근 팟캐스트 (horizontal) — `/recent/feeds`
+- ✅ 랜덤 에피소드 (vertical, 6개) — `/episodes/random`
+- ✅ 선호 인기 팟캐스트 (horizontal) — `/podcasts/trending`
+- ✅ 팔로우 팟캐스트 (horizontal)
+- ✅ 지역 인기 팟캐스트 (horizontal) — `/podcasts/trending`
+- ✅ 해외 인기 팟캐스트 (horizontal) — `/podcasts/trending`
+- ✅ 라이브 에피소드 (vertical) — `/episodes/live`
+- ✅ 채널 리스트 (horizontal) — DB + `/search/byterm`
+- ✅ 데이터 없는 섹션 자동 숨김 (#92)
+- ✅ 스크롤 fling 종료 시 움찔거림 제거 (#79)
+- 🟡 섹션별 '더보기' — `PodcastsSection`이 `onMore`를 사용하지 않아 버튼이 렌더되지 않음
+  (`core/ui/Podcast.kt:66`)
 
-local db
+### 1.3 검색
 
-#### 1. 메인
+- ✅ 통합 검색창 — `/search/byterm`, `/episodes/byfeedid`
+    - ✅ 팟캐스트 결과 (vertical)
+    - ✅ 에피소드 결과 (vertical)
+    - ✅ 검색 히스토리 — 검색어 + 팟캐스트/에피소드 클릭 기록, FlowRow 칩(칩별 삭제)
+- ✅ 최근 에피소드 (horizontal) — `/recent/episodes`
+- 🟡 인기 팟캐스트 — horizontal 노출까지만. vertical 상세와 Global/Korean/Categories 필터 칩 없음
+  (VM이 `max`만 전달, `language`/`categories` 미사용)
+- 🟡 카테고리 리스트 — State·Action·Effect는 있으나 화면이 `Category`를 import하지 않아 렌더 불가,
+  `NavigateToCategory`는 빈 처리 (`SearchScreen.kt:85`)
+- ⬜ 검색 상세 화면 — 라우트가 `SearchRoute` 단일이라 아래 두 항목 모두 진입점 없음
+    - ⬜ 최근 팟캐스트 리스트 (`/recent/feeds`)
+    - ⬜ 최근 에피소드 리스트 (vertical)
 
-- ✅ 검색창
-- ⬜ For you
-- ✅ Recently listen
-- ⬜ Saved
-- ✅ Liked
-- ✅ Followed
+> 검색은 원격 API 기반입니다. `PodcastFtsEntity`/`EpisodeFtsEntity`는 DB에 정의돼 있으나 검색 경로에 연결돼 있지 않습니다.
 
-#### 2. 상세
+### 1.4 라이브러리
 
-- ✅ chips (For you, Recently listen, Saved, Liked, Followed)
-- ⬜ For you, 랜덤 에피소드 리스트 (horizontal)
-    - /episodes/random (lang, cat)
-- ✅ Recently listen, 최근 재생 에피소드 리스트 (horizontal)
-- ⬜ Saved, 저장된 팟캐스트 리스트 (horizontal)
-- ✅ Liked, 좋아요 표시한 에피소드 리스트 (horizontal)
-- ✅ Followed, 구독한 팟캐스트 리스트 (horizontal)
+로컬 DB 기반. 상세 목록은 모두 **vertical 페이징 리스트**입니다(메인의 캐러셀만 horizontal).
 
-### 클립
+- ✅ 라이브러리 통합 검색 — 팟캐스트/에피소드/좋아요/저장/팔로우 대상 (`FindInLibraryUseCase`)
+- ✅ 섹션 필터 칩 — All · 최근 청취 · 좋아요 · 저장 · 팔로우 · 선호하는 (6종)
 
-- ✅ 구간 미리듣기
+| 섹션 | 메인 캐러셀 | 상세 목록 |
+|:----|:--:|:----|
+| 최근 청취 | ✅ | ✅ 날짜 구분선 포함 |
+| 좋아요 | ✅ | ✅ 항목별 토글 |
+| 저장 (에피소드) | ✅ | ✅ 토글 + Undo 스낵바 → [2.3](#23-저장--오프라인) |
+| 팔로우 | ✅ | ✅ 언팔로우 + 상세 진입 |
+| 선호하는 | — | ✅ 선호 카테고리 칩 편집 (#72) |
+
+- ⬜ For you (추천 피드) — 코드에 없음
+
+### 1.5 클립
+
+- ✅ 구간 미리듣기 — VerticalPager 자동 재생, Clip 전용 플레이어
 - ✅ 에피소드 좋아요
 - ✅ 에피소드 재생
-- ✅ 클립 자동 넘어가기
+- ✅ 클립 자동 넘어가기 — 재생 종료 시 다음 페이지로 스크롤
 
-## 공통 화면
+### 1.6 팟캐스트 상세
 
-### 팟캐스트 상세
+- ✅ 이미지 / 제목 / 설명(HTML 렌더)
+- ✅ 에피소드 목록 (Paging)
+- ✅ 앨범 아트 기반 동적 테마
+- ✅ 팟캐스트 공유 — 원본 웹사이트/RSS 링크 (`ACTION_SEND`)
 
-- ✅ image
-- ✅ title
-- ✅ description
-- ✅ episodes
+### 1.7 채널 상세
 
-### 에피소드 플레이어
+- ✅ 채널별 팟캐스트 탐색 (`:feature:channel`) — 홈의 채널 리스트가 진입점
 
-- ✅ image
-- ✅ title
-- ✅ description
-- ✅ progress bar
-- ✅ controls
-- ✅ chapter
-- ✅ transcript
-- ✅ playlist
-- ✅ playback speed
-- ⬜ sleep timer
-- ✅ foreground service player
-- ✅ 마지막 재생 리스트, 재생 에피소드 유지
+> 이 화면의 세부 기능은 아직 항목 단위로 감사하지 않았습니다.
 
-## 백그라운드
+### 1.8 에피소드 플레이어
 
-- ✅ 주기적 팔로우한 팟캐스트들 신규 에피소드 업데이트 (WorkManager, 3시간 주기)
-- ✅ 신규 에피소드 notification (썸네일 이미지 포함)
-- ✅ 알림 클릭 시 팟캐스트 상세 화면으로 딥링크 네비게이션
-- ✅ 알림 다국어 지원 (한/영 string resource)
+- ✅ 이미지 / 제목 / 설명
+- ✅ 진행 바 · 재생 컨트롤 (재생·일시정지, 이전·다음, −15초 / +30초)
+- ✅ 재생 속도 조절
+- ✅ 챕터
+- ✅ 트랜스크립트 — 재생 중 자막 큐 오버레이
+    - MIME이 `TEXT_VTT`로 고정돼 있어 SRT/JSON 트랜스크립트는 로드되지 않음
+    - 전문 스크롤·검색 뷰어는 없음
+- ✅ 플레이리스트
+- ✅ 슬립 타이머 (#73) — 시간 프리셋 + 에피소드 끝까지, 만료 15초 전 페이드아웃
+- ✅ 다운로드 상태·진행률 표시 (#77) — 링 진행률 버튼
+- ✅ 포그라운드 서비스 재생 (MediaNotificationService)
+- ✅ 마지막 재생 리스트·재생 위치 유지 — 프로세스 재시작 시 복원
 
-## 추가 기능 (미디어 컨텐츠 앱 일반 기능)
+---
 
-### Saved & 오프라인
+## 2. 시스템 통합
 
-- ⬜ 에피소드 저장 (Saved)
-- ⬜ 저장 관리 (삭제, 재저장)
-- ⬜ Wi-Fi 전용 저장 설정
+### 2.1 백그라운드 동기화 · 알림
 
-### 재생 기능
+- ✅ 팔로우 팟캐스트 신규 에피소드 주기 동기화 — WorkManager, 3시간 (#70, #76)
+    - ✅ 실패 시 지수 백오프 재시도 (30분 시작)
+- ✅ 신규 에피소드 알림 — Coil로 썸네일을 Bitmap 변환해 `setLargeIcon`
+- ✅ 알림 클릭 시 팟캐스트 상세 딥링크
+- ✅ 알림 다국어 (한/영)
 
-- ⬜ Sleep timer
+### 2.2 홈 화면 위젯
+
+- ✅ Glance 기반 단일 리사이즈 위젯 (#74 → #75) — 재생 + 최근 피드 통합, 3x1~4x3
+- ✅ 위젯에서 재생 제어
+- ✅ 위젯 탭 시 자동 재생 딥링크 (콜드스타트 포함)
+- ✅ Palette 기반 배경색 추출 · 로딩 상태
+
+### 2.3 저장 · 오프라인
+
+- ✅ 에피소드 저장 — 홈·검색·팟캐스트·플레이어·라이브러리에서 토글, `DownloadManager`로 다운로드
+- ✅ 저장 해제 — 다운로드 취소 + 파일 삭제
+- ✅ Undo 스낵바 (스와이프 dismiss 포함) (#71) — 저장 해제에만 적용
+- ✅ 오프라인 재생 (#78) — 다운로드된 파일이 있으면 로컬 파일 우선, 없으면 스트리밍 폴백
+- ⬜ Wi-Fi 전용 다운로드 설정 — `setAllowedOverMetered(true)` 고정, [4.1](#41-선행-과제-설정-화면)에 종속
+- ⬜ 팔로우 팟캐스트 자동 저장
+
+> 전용 다운로드 관리 화면은 없고 라이브러리 '저장' 탭이 그 역할을 겸합니다.
+
+### 2.4 딥링크 · 권한
+
+- ✅ 딥링크 처리 — 알림 딥링크, 위젯 자동 재생 딥링크 2종
+- 🟡 런타임 권한 요청 (`POST_NOTIFICATIONS`) — 요청·허용은 동작하나
+  rationale 화면과 거부 후속 UX가 없어 미허용 시 콜드스타트마다 재요청됨
+
+---
+
+## 3. 품질
+
+### 3.1 오류 처리 & 복구 (#95)
+
+- ✅ `DataError` 도메인 에러 타입 + 네트워크 예외 매핑
+- ✅ 에러 화면 + 재시도 — 채널·홈·라이브러리·온보딩·팟캐스트·검색 6개 화면
+- ✅ 캐시 유지 정책 — 갱신 실패 시 캐시가 있으면 유지, 없을 때만 에러 전파 (`RemoteUpdater`)
+- ✅ 네트워크 타임아웃 명시 설정
+
+### 3.2 로딩 & 상태 표현
+
+- ✅ Shimmer 스켈레톤 (#94) — 홈·검색·팟캐스트·라이브러리·온보딩·채널·클립 전 화면
+- ✅ 빈 상태 처리 — 데이터 없는 홈 섹션 숨김 (#92)
+
+### 3.3 테스트 & CI
+
+- ✅ 유닛 테스트 — 122개 파일 / `@Test` 1,083개
+- ✅ Kover 커버리지 (#84) — CI 하한 80% (전환 후 overall 86.8%로 재baseline)
+- ✅ GitHub Actions — `android.yml`, `publish.yml`
+- ⬜ 테스트 공백 — `:core:designsystem`, `:core:testing` 테스트 0개
+
+### 3.4 접근성
+
+- 🟡 `contentDescription` — feature 모듈 51건 적용(6건은 의도적 `null`).
+  `semantics` 커스터마이징과 TalkBack 실측 검증은 없음
+
+### 3.5 아키텍처
+
+- ✅ Navigation 3 전환 (#69)
+- ✅ Offline-First — `RemoteUpdater` + `CacheableQuery` (Podcast·Episode 대상)
+- ✅ v2 디자인 시스템 적용 (#90) — [DESIGN.md](../DESIGN.md)
+
+---
+
+## 4. 백로그
+
+### 4.1 선행 과제: 설정 화면
+
+설정 화면이 없어 아래 항목들이 함께 막혀 있습니다. 개별 기능보다 먼저 처리해야 합니다.
+
+- ⬜ 설정 화면 신설 — 현재 DataStore 키는 `is_first_launch`, `categories`, `speed`, `last_playing_*` 뿐
+- ⬜ 인앱 다크/라이트 테마 전환 — 시스템 다크모드 추종은 동작하나(✅ `darkScheme`/`lightScheme` 실재)
+  사용자가 앱 안에서 고를 수단과 영속 설정이 없음. Dynamic Color도 `false` 고정
+- ⬜ Wi-Fi 전용 다운로드 → [2.3](#23-저장--오프라인)
+- ⬜ 팔로우 팟캐스트 자동 저장
+
+### 4.2 재생 기능
+
 - ⬜ 이퀄라이저
-- ⬜ 구간 반복 (A-B repeat)
+- ⬜ 구간 반복 (A-B repeat) — 재생목록 반복(`Repeat.OFF/ONE/ALL`)은 별개로 구현돼 있음
 - ⬜ 북마크 / 타임스탬프 메모
 
-### 알림 & 동기화
+### 4.3 공유 · 연동
 
-- ✅ 신규 에피소드 알림 (로컬, WorkManager 기반)
-- ⬜ 구독 팟캐스트 자동 저장
+- ⬜ 에피소드 공유 — 현재 공유는 팟캐스트 단위 원본 링크만
+- ⬜ 클립 공유 (타임스탬프 포함)
+- ⬜ 앱 딥링크 스킴 기반 공유
 - ⬜ OPML import / export
 
-### 소셜 & 공유
+### 4.4 분석
 
-- ⬜ 에피소드 공유 (딥링크)
-- ⬜ 클립 공유 (타임스탬프 포함)
-
-### 접근성 & UX
-
-- ✅ 런타임 권한 요청 (POST_NOTIFICATIONS 등)
-- ⬜ 다크 / 라이트 테마 전환
-- ⬜ 홈 화면 위젯
-- ✅ 딥링크 처리
-
-### 분석 & 모니터링
-
-- ⬜ 청취 통계 (일별 / 주별 / 월별)
+- ⬜ 청취 통계 (일별/주별/월별) — `PlayedEpisodeEntity`로 데이터 원천은 있으나 집계·화면 없음
 - ⬜ 앱 분석 (Firebase Analytics 등)
+
+---
+
+## 5. 알려진 한계
+
+구현했지만 범위를 좁힌 것들입니다. 미착수 항목([4](#4-백로그))과 구분합니다.
+
+| 항목 | 한계 |
+|:----|:----|
+| 오류 처리 (#95) | 플레이어 화면에는 에러 화면·재시도가 적용되지 않음 |
+| Paging 재시도 | 라이브러리 4개 탭·팟캐스트 에피소드·온보딩 추천의 Paging 스트림은 재시도 경로가 별도 |
+| HTTP 응답 검증 | 200 응답의 논리적 실패(`status`/`description` 필드)를 검증하지 않음 |
+| NetworkMonitor | 데이터 계층에 연결되지 않음 |
+| 캐시 정책 | `RemoteUpdater`의 stale-while-error가 Podcast·Episode에만 적용 (Channel·RecentSearch·User·Player는 대상 밖) |
+| 트랜스크립트 | VTT 전용, 전문 뷰어 없음 |
+| 슬립 타이머 | 30초 프리셋에 `TODO: 테스트용, 출시 시 제거` 주석 잔존 (`PlayerScreen.kt:1184`) |
+| 홈 '더보기' | `PodcastsSection`이 `onMore`를 사용하지 않아 버튼 미노출 |
+
+### 미감사 영역
+
+- 채널 상세 화면(`:feature:channel`) 내부 기능
+- 접근성 실측 (TalkBack)
+- 릴리스 빌드 / ProGuard / 성능·전력


### PR DESCRIPTION
## 변경 사항

`docs/IMPLEMENTATION_CHECKLIST.md`가 커밋 `30fbb36`(#70)에서 멈춰 있어 **이후 25개 PR이 반영되지 않았습니다.** 전 항목을 코드에 대조해 갱신하고, 같은 일이 반복되지 않도록 구조를 바꿨습니다.

### 가장 심각했던 문제

구현이 끝났는데 미구현(⬜)으로 방치된 항목이 5개였습니다. 문서 전체의 신뢰도를 무너뜨리는 1순위 문제였습니다.

| 항목 | 문서 | 실제 |
|:--|:--:|:--|
| Sleep timer | ⬜ (2곳 중복) | ✅ #73 |
| 홈 화면 위젯 | ⬜ | ✅ #74 → #75 |
| 에피소드 저장 | ⬜ | ✅ 5개 화면에서 토글 |
| 저장 관리 | ⬜ | ✅ 다운로드 취소 + 파일 삭제 |
| 라이브러리 Saved | ⬜ | ✅ (대상이 팟캐스트가 아니라 **에피소드**) |

### 구조 변경

- **4층으로 재편** — 사용자 여정 / 시스템 통합 / 품질 / 백로그, 그리고 **알려진 한계**를 별도 절로. 최근 15개 PR의 산출물(#71·#84·#94·#95)이 전부 "기능"이 아니라 "품질"이라 기존 목차에는 들어갈 자리가 없었습니다.
- **상태 어휘를 3단계로** (✅ / 🟡 부분 구현 / ⬜) — 기존 2단계로는 "데이터 계층만 있고 UI에 연결 안 됨"을 ✅ 또는 ⬜ 어느 쪽으로도 왜곡할 수밖에 없었습니다. 해당 항목이 7건입니다.
- **중복 제거** — 같은 기능이 여러 절에 서로 다른 상태로 있었습니다 (Sleep timer, 신규 에피소드 알림, 런타임 권한, 딥링크, Saved).
- **항목명을 실제 구현명으로 교정** — `For you` 칩(실제는 `All`·`선호하는`), `저장된 팟캐스트`(실제는 에피소드 저장이며 팟캐스트 저장은 코드에 없음). 항목명이 구현과 어긋나면 영원히 ⬜로 남습니다.
- **레이아웃 표기 수정** — 라이브러리 상세 4항목이 `horizontal`로 쓰여 있었지만 실제는 vertical 페이징 리스트입니다. 이 문구 오류가 감사 과정에서 "부분 구현" 오판 3건을 유발했습니다.
- **누락 항목 추가** — 채널 상세 화면(`:feature:channel`), 오프라인 재생(#78), 다운로드 진행률(#77), Undo 스낵바(#71), 오류 처리·캐시 유지(#95), shimmer 스켈레톤(#94), 테스트·CI(#84), Navigation 3(#69).
- **선행 과제 명시** — 테마 전환·Wi-Fi 전용 다운로드·자동 저장이 모두 **설정 화면 부재**에 종속됨을 백로그 상단에 드러냈습니다.

각 항목에 근거(PR 번호 또는 `파일:줄`)를 붙여, 다음 감사 때 전수 조사를 다시 하지 않아도 되게 했습니다.

## 테스트

문서 변경이라 코드 테스트는 없습니다. 대신 **모든 판정을 코드에 대조**했고, 실행으로 확인 가능한 것은 확인했습니다.

판정이 뒤집힌 항목:

- **transcript** — 조사 단계에서 "미구현"으로 판정됐으나 오판이었습니다. `transcript` 문자열만 검색해 cue 경유 경로를 놓친 것으로, 실제로는 `SubtitleConfiguration` → `onCues` → `PushUpCue`까지 연결돼 있습니다. ✅로 두되 MIME이 `TEXT_VTT` 고정이라는 한계를 명기했습니다.
- **다크/라이트 테마** — `darkScheme`/`lightScheme`이 실재하고 시스템 설정을 따라가지만, 앱 안에서 전환할 UI와 영속 설정이 없어 ⬜로 두고 사유를 적었습니다.
- **권한 요청** — 트리거가 온보딩이 아니라 앱 콜드스타트라 온보딩 절에서 빼고, rationale·거부 후속 UX가 없어 🟡로 조정했습니다.

## 참고

이번 감사에서 발견했지만 이 PR 범위 밖이라 손대지 않은 것:

- **릴리스 리스크** — 슬립 타이머 30초 프리셋에 `TODO: 테스트용, 출시 시 제거` 주석이 남아 있습니다 (`PlayerScreen.kt:1184`).
- `CLAUDE.md`의 모듈 수가 20개(feature 8)로 적혀 있으나 실제는 **21개(feature 9)** 입니다 — `:feature:widget` 누락.
- `docs/COVERAGE_REPORT.md`가 2026-03-31에서 멈춰 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DLsxHwqXt44iH1dRNAC4S