### PR TITLE
fix: 슬립 타이머 30초 프리셋을 15분으로 교체

### DIFF
--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerScreen.kt
@@ -1173,16 +1173,16 @@ private fun SleepTimerSheet(
     }
 
     // 한 줄에 들어가는 다섯 개까지만 둔다. 줄바꿈되면 시트가 세로로 늘어나 다이얼·버튼이 밀린다.
+    // 커스텀 시간 입력이 없어 이 다섯 개가 선택지의 전부이므로, 칸을 잠들지 않을 시간에 쓰지 않는다.
     val timerPresets = remember {
         listOf(
-            30L * 1000,
             5L * 60 * 1000,
             10L * 60 * 1000,
+            15L * 60 * 1000,
             30L * 60 * 1000,
             60L * 60 * 1000,
         )
     }
-    // TODO: 30초 프리셋은 테스트용. 출시 시 제거
     val isActive = remainingMs != null
 
     ModalBottomSheet(
@@ -1253,16 +1253,11 @@ private fun SleepTimerSheet(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     timerPresets.forEach { durationMs ->
-                        val totalSeconds = (durationMs / 1000).toInt()
-                        // 단위는 로케일 리소스가 붙인다 (한국어 "초/분", 영어 "s/m").
-                        val label = if (totalSeconds < 60) {
-                            stringResource(R.string.feature_player_sleep_timer_seconds, totalSeconds)
-                        } else {
-                            stringResource(
-                                R.string.feature_player_sleep_timer_minutes,
-                                totalSeconds / 60
-                            )
-                        }
+                        // 단위는 로케일 리소스가 붙인다 (한국어 "분", 영어 "m").
+                        val label = stringResource(
+                            R.string.feature_player_sleep_timer_minutes,
+                            (durationMs / 1000 / 60).toInt(),
+                        )
                         PlayerPresetCircle(
                             size = PlayerSleepTimerPresetSize,
                             label = label,

--- a/feature/player/src/main/res/values-ko/strings.xml
+++ b/feature/player/src/main/res/values-ko/strings.xml
@@ -12,7 +12,6 @@
     <string name="feature_player_sleep_timer_end_of_episode">에피소드 끝까지</string>
     <string name="feature_player_sleep_timer_expired">슬립 타이머가 종료되었습니다</string>
     <string name="feature_player_sleep_timer_minutes">%d분</string>
-    <string name="feature_player_sleep_timer_seconds">%d초</string>
     <string name="feature_player_sleep_timer_requires_playback">재생 중에만 슬립 타이머를 설정할 수 있습니다</string>
     <string name="feature_player_playlist_title">재생목록</string>
     <string name="feature_player_playlist_queue_count">%d개 대기 중</string>

--- a/feature/player/src/main/res/values/strings.xml
+++ b/feature/player/src/main/res/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="feature_player_sleep_timer_end_of_episode">End of Episode</string>
     <string name="feature_player_sleep_timer_expired">Sleep timer expired</string>
     <string name="feature_player_sleep_timer_minutes">%dm</string>
-    <string name="feature_player_sleep_timer_seconds">%ds</string>
     <string name="feature_player_sleep_timer_requires_playback">Play an episode first to set a sleep timer</string>
     <string name="feature_player_playlist_title">Playlist</string>
     <string name="feature_player_playlist_queue_count">%d queued</string>


### PR DESCRIPTION
## 변경 사항

30초 프리셋에 `TODO: 30초 프리셋은 테스트용. 출시 시 제거` 주석이 남아 있었습니다. 제거하면서 그 자리를 비우지 않고 **15분으로 채웠습니다.**

### 왜 15분인가

- **30초는 용도가 성립하지 않습니다.** 슬립 타이머는 잠들 때까지 재생하는 기능인데 30초에 잠드는 사람은 없습니다. Spotify·Apple Podcasts·Pocket Casts·YouTube Music 모두 최소 5분부터 시작합니다.
- **칸이 아깝습니다.** 이 화면에는 커스텀 시간 입력이 없어서 **프리셋 다섯 개가 사용자 선택지의 전부**입니다(그 외에는 `에피소드 끝까지`뿐). 코드 주석도 *"한 줄에 들어가는 다섯 개까지만 둔다"* 는 제약을 명시하고 있습니다. 그 한 칸을 30초가 쓰는 바람에 15분이 빠져 있었고, 결과적으로 10분 다음이 바로 30분이라 간격이 벌어져 있었습니다.

`5 · 10 · 15 · 30 · 60분`은 다른 앱들의 표준 구성이기도 합니다.

### 함께 정리된 것

60초 미만 프리셋이 30초 하나뿐이었어서, 제거하니 죽은 코드가 따라 나왔습니다.

- 라벨의 초/분 분기 (`if (totalSeconds < 60)`) 제거
- `feature_player_sleep_timer_seconds` 문자열 리소스 제거 (한·영 2개)

순증 -7줄입니다.

## 테스트

**전체 1,076개 통과 (실패 0)**, `:feature:player` 73개 포함.

기존 슬립 타이머 테스트는 `PlayerViewModel` 레벨에서 `SetSleepTimer(60_000L)` 같은 임의 값을 직접 넘기므로 UI 프리셋 목록과 무관합니다 — 수정이 필요 없었습니다.

`:feature:player:lintDebug` 0 errors (제거한 문자열 리소스의 잔여 참조 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DLsxHwqXt44iH1dRNAC4S