### PR TITLE
fix: 다른 에피소드를 재생하면 이전 재생 위치가 지워지는 문제

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,26 @@ Hilt `@Player` qualifier로 ExoPlayer 인스턴스 두 개 관리:
 - `@Player(EpisodivePlayers.Main)` — 전체 에피소드 재생
 - `@Player(EpisodivePlayers.Clip)` — 사운드바이트/클립 재생
 
+### 재생 위치 저장 규약 (필수)
+
+재생 위치는 **`Progress.episodeId` 를 키로만** 저장한다. 저장 경로(`PlayerViewModel` 의 progress
+콜렉터, `LastPlaySnapshot`, 수면 타이머)는 `playerRepository.progress` 하나만 구독한다.
+
+**에피소드 id 를 `nowPlaying` 같은 다른 Flow 에서 가져와 `combine` 하지 마라.** `nowPlaying` 은
+Room 왕복과 `flowOn(IO)` 를 거쳐 `progress` 보다 늦게 도착한다. 전환 순간 `(이전 에피소드, 새 위치)`
+쌍이 만들어지고 그대로 저장되어 **이전 에피소드의 이어듣기 지점이 사라진다.** 실제로 겪은 버그다.
+
+`PlayerDataSourceImpl` 쪽 규약:
+- progress 발행은 `publishProgress()` 를 거치고 **반드시 `episodeId` 를 함께 싣는다.** 빠뜨리면
+  그 경로의 저장이 조용히 멈춘다(오염이 아니라 무저장이라 눈치채기 어렵다).
+- `episodeId` 는 `_nowPlaying` 이 아니라 `currentEpisode()`(= 플레이어에 실제로 올라 있는 항목)에서
+  얻는다. `rehydrate` 가 `_nowPlaying` 을 플레이어와 무관하게 바꿀 수 있다.
+- media3 는 `setMediaItems` 호출 스택 안에서 transition 콜백을 **인라인 실행**한다. 목록을 통째로
+  갈아끼우는 경로(`prepare`/`play(list, index)`/`playClips`)는 `isPreparing` 으로 그동안의 발행을 막고,
+  끝난 뒤 확정값을 한 번만 발행한다.
+- `position == 0 이면 저장하지 않는다` 류 가드를 넣지 마라. "맨 앞으로 되감기" 와 "완료 후 처음부터
+  다시 듣기" 가 0 을 저장해야 정상이다. `PlayerViewModelTest` 에 이를 지키는 계약 테스트가 있다.
+
 ## 중요 구현 세부사항
 
 ### 1. Enum 처리 (필수)

--- a/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/usecase/player/RestoreLastPlayStateUseCase.kt
+++ b/core/domain/src/main/kotlin/io/jacob/episodive/core/domain/usecase/player/RestoreLastPlayStateUseCase.kt
@@ -20,7 +20,22 @@ class RestoreLastPlayStateUseCase @Inject constructor(
 
         val matchedIndex = playlist.indexOfFirst { it.id == lastState.episodeId }
         val index = if (matchedIndex >= 0) matchedIndex else lastState.index.coerceIn(0, playlist.size - 1)
-        playerRepository.prepare(playlist, index, lastState.positionMs)
+        val target = playlist[index]
+        val dbPositionMs = target.position.inWholeMilliseconds
+        // 복원 위치는 항상 "그 에피소드 자신의" 위치여야 한다.
+        //
+        // 찾은 경우: DataStore 스냅샷과 DB 중 앞선 쪽을 쓴다. 스냅샷은 5초 간격으로만 저장되므로
+        // 0.5초마다 갱신되는 DB 보다 최대 그만큼 뒤처져 있고, 그대로 쓰면 앱을 켤 때마다 되감긴다.
+        //
+        // 못 찾아 인덱스로 폴백한 경우: 스냅샷 위치는 사라진 에피소드의 것이므로 버리고
+        // 폴백 대상 자신의 위치를 쓴다. 남의 위치를 물려주면 그 값이 곧바로 저장되어
+        // 폴백 대상의 이어듣기 지점이 오염된다.
+        val positionMs = if (matchedIndex >= 0) {
+            maxOf(lastState.positionMs, dbPositionMs)
+        } else {
+            dbPositionMs
+        }
+        playerRepository.prepare(playlist, index, positionMs)
         playerRepository.setShuffle(lastState.shuffle)
         playerRepository.setRepeat(lastState.repeat)
         return true

--- a/core/domain/src/test/kotlin/io/jacob/episodive/core/domain/usecase/player/RestoreLastPlayStateUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/io/jacob/episodive/core/domain/usecase/player/RestoreLastPlayStateUseCaseTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
 
 class RestoreLastPlayStateUseCaseTest {
     @get:Rule
@@ -117,8 +118,12 @@ class RestoreLastPlayStateUseCaseTest {
             }
         }
 
+    // 저장된 에피소드(123L)가 플레이리스트에 없어 인덱스로 폴백하는 경우다.
+    // 이때 저장된 위치는 사라진 에피소드의 것이므로 함께 버려야 한다.
+    // 그대로 물려주면 폴백 대상 에피소드가 그 위치에서 시작하고, 그 값이 곧바로
+    // 저장되어 해당 에피소드의 이어듣기 지점이 오염된다.
     @Test
-    fun `Given index exceeds playlist size, When invoke, Then coerces index to last element`() =
+    fun `Given saved episode is missing from playlist, When invoke, Then coerces index and discards position`() =
         runTest {
             // Given
             val playlist = episodeTestDataList.take(3)
@@ -145,7 +150,122 @@ class RestoreLastPlayStateUseCaseTest {
             coVerifySequence {
                 userRepository.getLastPlayState()
                 episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
-                playerRepository.prepare(playlist, 2, 1000L)
+                playerRepository.prepare(playlist, 2, 0L)
+                playerRepository.setShuffle(false)
+                playerRepository.setRepeat(Repeat.OFF)
+            }
+        }
+
+    // DataStore 스냅샷은 5초 간격으로만 저장되어 0.5초마다 갱신되는 DB 보다 최대 그만큼
+    // 뒤처질 수 있다. DB 위치가 스냅샷보다 앞서면 DB 위치를 써야 앱을 켤 때마다 되감기는
+    // 문제가 생기지 않는다.
+    @Test
+    fun `Given db position ahead of snapshot, When invoke, Then prepares with db position`() =
+        runTest {
+            // Given
+            val playlist = episodeTestDataList.take(3).toMutableList()
+            playlist[1] = playlist[1].copy(position = 13.seconds)
+            val lastState = LastPlayState(
+                episodeId = playlist[1].id,
+                index = 1,
+                positionMs = 10_000L,
+                shuffle = false,
+                repeat = Repeat.OFF,
+            )
+            coEvery { userRepository.getLastPlayState() } returns lastState
+            coEvery {
+                episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
+            } returns playlist
+            every { playerRepository.prepare(any(), any(), any()) } just Runs
+            every { playerRepository.setShuffle(any()) } just Runs
+            every { playerRepository.setRepeat(any()) } just Runs
+
+            // When
+            val result = useCase()
+
+            // Then
+            assertTrue(result)
+            coVerifySequence {
+                userRepository.getLastPlayState()
+                episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
+                playerRepository.prepare(playlist, 1, 13_000L)
+                playerRepository.setShuffle(false)
+                playerRepository.setRepeat(Repeat.OFF)
+            }
+        }
+
+    // 반대로 스냅샷이 DB 보다 앞설 수도 있다(예: 종료 직전 위치가 DB 에 아직 반영되지
+    // 않은 경우). 이때는 스냅샷 값을 써야 한다 — maxOf 를 minOf 로 잘못 구현하면 이 테스트가
+    // 실패한다.
+    @Test
+    fun `Given snapshot ahead of db position, When invoke, Then prepares with snapshot position`() =
+        runTest {
+            // Given
+            val playlist = episodeTestDataList.take(3).toMutableList()
+            playlist[1] = playlist[1].copy(position = 13.seconds)
+            val lastState = LastPlayState(
+                episodeId = playlist[1].id,
+                index = 1,
+                positionMs = 20_000L,
+                shuffle = false,
+                repeat = Repeat.OFF,
+            )
+            coEvery { userRepository.getLastPlayState() } returns lastState
+            coEvery {
+                episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
+            } returns playlist
+            every { playerRepository.prepare(any(), any(), any()) } just Runs
+            every { playerRepository.setShuffle(any()) } just Runs
+            every { playerRepository.setRepeat(any()) } just Runs
+
+            // When
+            val result = useCase()
+
+            // Then
+            assertTrue(result)
+            coVerifySequence {
+                userRepository.getLastPlayState()
+                episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
+                playerRepository.prepare(playlist, 1, 20_000L)
+                playerRepository.setShuffle(false)
+                playerRepository.setRepeat(Repeat.OFF)
+            }
+        }
+
+    // 저장된 에피소드가 목록에 없어 인덱스로 폴백하는 경우, 스냅샷 위치는 사라진
+    // 에피소드의 것이므로 버리고 폴백 대상 자신의 DB 위치를 써야 한다. 폴백 대상의
+    // position 이 0 이 아닌 값으로 세팅되어 있을 때, 스냅샷 값도 0 도 아닌 그 값이
+    // 그대로 쓰이는지 검증한다.
+    @Test
+    fun `Given saved episode missing and fallback target has db position, When invoke, Then prepares with fallback target's own db position`() =
+        runTest {
+            // Given
+            val playlist = episodeTestDataList.take(3).toMutableList()
+            playlist[2] = playlist[2].copy(position = 42.seconds)
+            val lastState = LastPlayState(
+                episodeId = 123L,
+                index = 99,
+                positionMs = 1000L,
+                shuffle = false,
+                repeat = Repeat.OFF,
+            )
+            coEvery { userRepository.getLastPlayState() } returns lastState
+            coEvery {
+                episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
+            } returns playlist
+            every { playerRepository.prepare(any(), any(), any()) } just Runs
+            every { playerRepository.setShuffle(any()) } just Runs
+            every { playerRepository.setRepeat(any()) } just Runs
+
+            // When
+            val result = useCase()
+
+            // Then
+            assertTrue(result)
+            coVerifySequence {
+                userRepository.getLastPlayState()
+                episodeRepository.getEpisodesByGroupKey(GroupKey.PLAYLIST.toString())
+                playerRepository.prepare(playlist, 2, 42_000L)
                 playerRepository.setShuffle(false)
                 playerRepository.setRepeat(Repeat.OFF)
             }

--- a/core/model/src/main/kotlin/io/jacob/episodive/core/model/Progress.kt
+++ b/core/model/src/main/kotlin/io/jacob/episodive/core/model/Progress.kt
@@ -7,6 +7,16 @@ data class Progress(
     val position: Duration,
     val buffered: Duration,
     val duration: Duration,
+    /**
+     * 이 진행률이 어느 에피소드의 것인지. 재생 위치를 DB 에 저장할 때 쓰는 유일한 키다.
+     *
+     * 위치와 에피소드를 한 값에 묶는 이유: 둘을 별도 Flow 로 두면 에피소드 전환 순간
+     * 지연이 다른 두 스트림이 어긋나 "이전 에피소드 + 새 위치" 쌍이 만들어지고,
+     * 그대로 저장되어 이전 에피소드의 이어듣기 지점이 오염된다.
+     *
+     * null 은 "재생 대상 미확정"(프로세스 시작 직후, rehydrate 직후)을 뜻하며 저장하지 않는다.
+     */
+    val episodeId: Long? = null,
 ) {
     val positionRatio: Float =
         if (duration.isPositive() && duration.toIntSeconds() > 0) {

--- a/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
+++ b/core/player/src/main/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImpl.kt
@@ -38,6 +38,10 @@ class PlayerDataSourceImpl @Inject constructor(
 ) : PlayerDataSource {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    // prepare() 가 setMediaItems 를 호출하는 동안 transition 콜백의 progress 발행을 막는 플래그.
+    // 콜백과 prepare() 는 같은 플레이어 스레드에서만 실행되므로 별도 동기화가 필요 없다.
+    private var isPreparing = false
+
     private val listener = object : Player.Listener {
         override fun onTimelineChanged(timeline: Timeline, reason: Int) {
             Timber.d(
@@ -87,11 +91,29 @@ class PlayerDataSourceImpl @Inject constructor(
             val episode = mediaItem?.localConfiguration?.tag as? Episode
             _nowPlaying.value = episode
             _indexOfList.value = player.currentMediaItemIndex
-            _progress.value = Progress(
-                position = Duration.ZERO,
-                buffered = Duration.ZERO,
-                duration = episode?.duration ?: Duration.ZERO,
-            )
+            // 재생목록을 통째로 갈아끼우는 중에는 발행하지 않는다. media3 가 setMediaItems 호출
+            // 스택 안에서 이 콜백을 인라인 실행하는데, 그때는 아직 목표 항목·위치에 도달하기 전이라
+            // 잘못된 쌍이 만들어진다. 그 값이 한 번이라도 발행되면 구독자가 그대로 저장해
+            // (세션 스냅샷은 throttle 탓에 정정값을 버린다) 이어듣기 지점이 날아간다.
+            // 갈아끼우기가 끝난 뒤 확정값을 한 번만 발행한다.
+            if (!isPreparing) {
+                // 자동 전환과 반복은 새 항목을 항상 처음부터 재생하므로 0 이 확정이다.
+                // 그 경우 player.currentPosition 을 읽으면 아직 이전 항목의 끝 위치일 수 있고,
+                // 그 값이 새 에피소드의 위치로 저장되면 듣지도 않은 에피소드가 완료 처리된다.
+                // 나머지(탐색·재생목록 교체)는 플레이어가 이미 목표 위치에 가 있다.
+                val position = when (reason) {
+                    Player.MEDIA_ITEM_TRANSITION_REASON_AUTO,
+                    Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT -> Duration.ZERO
+
+                    else -> player.currentPosition.toDurationMillis()
+                }
+                publishProgress(
+                    position = position,
+                    buffered = Duration.ZERO,
+                    duration = episode?.duration ?: Duration.ZERO,
+                    episodeId = episode?.id,
+                )
+            }
         }
 
         override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
@@ -222,8 +244,25 @@ class PlayerDataSourceImpl @Inject constructor(
     // so the user can choose when to start playback after app restart.
     override fun prepare(episodes: List<Episode>, indexToPlay: Int, positionMs: Long) {
         val mediaItems = episodes.map { it.toMediaItem(isClip = false) }
-        player.setMediaItems(mediaItems, indexToPlay, positionMs)
-        player.prepare()
+        // media3 는 setMediaItems 안에서 onMediaItemTransition 을 인라인 실행한다. 그 사이의
+        // 발행을 막아, 복원 위치가 잘못된 중간값으로 한 번도 노출되지 않게 한다.
+        isPreparing = true
+        try {
+            player.setMediaItems(mediaItems, indexToPlay, positionMs)
+            player.prepare()
+        } finally {
+            isPreparing = false
+        }
+
+        // 확정값을 여기서 한 번만 발행한다.
+        // 이 시점 player.duration 은 아직 TIME_UNSET 이므로 에피소드 메타의 길이를 쓴다.
+        val target = episodes.getOrNull(indexToPlay)
+        publishProgress(
+            position = positionMs.toDurationMillis(),
+            buffered = Duration.ZERO,
+            duration = target?.duration ?: Duration.ZERO,
+            episodeId = target?.id,
+        )
     }
 
     override fun play(episode: Episode) {
@@ -241,10 +280,20 @@ class PlayerDataSourceImpl @Inject constructor(
         }
         val mediaItems = episodes.map { it.toMediaItem(isClip = false) }
 
-        player.setMediaItems(mediaItems)
-        indexToPlay?.let { player.seekToDefaultPosition(it) }
-        player.prepare()
+        // setMediaItems 는 목록의 첫 항목으로 transition 을 인라인 발생시킨다. 목표가 첫 항목이
+        // 아니면 그 사이에 "재생하지도 않을 에피소드 + 위치 0" 이 발행되어 그 에피소드의
+        // 이어듣기 지점이 지워진다. seekToDefaultPosition 으로 목표에 도달할 때까지 막는다.
+        isPreparing = true
+        try {
+            player.setMediaItems(mediaItems)
+            indexToPlay?.let { player.seekToDefaultPosition(it) }
+            player.prepare()
+        } finally {
+            isPreparing = false
+        }
         player.playWhenReady = true
+
+        publishStartOfPlayback(episodes.getOrNull(indexToPlay ?: 0))
     }
 
     override fun playClip(episode: Episode) {
@@ -262,10 +311,18 @@ class PlayerDataSourceImpl @Inject constructor(
         }
         val mediaItems = episodes.map { it.toMediaItem(isClip = true) }
 
-        player.setMediaItems(mediaItems)
-        indexToPlay?.let { player.seekToDefaultPosition(it) }
-        player.prepare()
+        // play(episodes, indexToPlay) 와 같은 이유로 목표 항목에 도달할 때까지 발행을 막는다.
+        isPreparing = true
+        try {
+            player.setMediaItems(mediaItems)
+            indexToPlay?.let { player.seekToDefaultPosition(it) }
+            player.prepare()
+        } finally {
+            isPreparing = false
+        }
         player.playWhenReady = true
+
+        publishStartOfPlayback(episodes.getOrNull(indexToPlay ?: 0))
     }
 
     override fun playIndex(index: Int) {
@@ -316,10 +373,18 @@ class PlayerDataSourceImpl @Inject constructor(
 
     override fun seekTo(position: Long) {
         player.seekTo(position)
-        _progress.value = Progress(
+        // 준비 전에는 player.duration 이 TIME_UNSET(음수)이라 그대로 실으면
+        // 시커와 수면 타이머가 쓰레기 값을 본다. 그럴 땐 에피소드 메타의 길이로 대신한다.
+        // 직전 progress 의 duration 을 쓰면 안 된다 — 전환 직후엔 그것이 이전 에피소드의
+        // 길이여서, 짧은 길이 + 큰 위치 조합이 완료 판정을 잘못 뒤집는다.
+        val duration = player.duration.toDurationMillis().takeIf { it.isPositive() }
+            ?: currentEpisode()?.duration
+            ?: Duration.ZERO
+        publishProgress(
             position = position.toDurationMillis(),
             buffered = player.bufferedPosition.toDurationMillis(),
-            duration = player.duration.toDurationMillis(),
+            duration = duration,
+            episodeId = currentEpisodeId(),
         )
     }
 
@@ -419,10 +484,69 @@ class PlayerDataSourceImpl @Inject constructor(
     }
 
     override fun rehydrate(episode: Episode) {
+        // 플레이어가 이미 다른 에피소드를 들고 있으면 그쪽이 진실이다.
+        // 이 가드가 없으면 서비스의 비동기 DB 읽기가 늦게 도착해 _nowPlaying 을 되돌리고,
+        // UI 는 A 를 보여주면서 B 를 재생하는 상태가 된다.
+        val playingEpisode = currentEpisode()
+        if (playingEpisode != null && playingEpisode.id != episode.id) return
         // 같은 episode 면 무시 (불필요한 widget 갱신/depounce 방지).
         if (_nowPlaying.value?.id == episode.id) return
         _nowPlaying.value = episode
         _isPlaying.value = player.isPlaying
+        // 여기서 _progress 를 세팅하지 말 것. 이 시점의 실제 재생 위치는 알 수 없고,
+        // episodeId 가 붙은 progress 를 발행하는 순간 그 값이 DB 에 저장되어
+        // 아직 듣지도 않은 위치로 이어듣기 지점이 덮어써진다.
+        // progress 는 progressUpdater 나 transition 콜백이 실제 값으로 채운다.
+    }
+
+    /**
+     * 지금 플레이어에 올라 있는 에피소드. 재생 위치의 주인을 판별하는 유일한 근거다.
+     *
+     * `_nowPlaying` 을 쓰지 않는 이유: rehydrate 가 플레이어 상태와 무관하게 그 값을 바꿀 수 있어,
+     * 실제로는 B 를 재생하면서 A 의 id 가 붙은 위치를 발행하는 오염이 생긴다.
+     * 플레이어 스레드에서만 호출할 것.
+     */
+    private fun currentEpisode(): Episode? =
+        player.currentMediaItem?.localConfiguration?.tag as? Episode
+
+    private fun currentEpisodeId(): Long? = currentEpisode()?.id
+
+    /**
+     * 재생목록을 갈아끼운 직후, 실제로 재생할 항목의 시작 상태를 발행한다.
+     * 갈아끼우는 동안 억제한 transition 콜백을 대신하는 확정 발행이다.
+     */
+    private fun publishStartOfPlayback(target: Episode?) {
+        publishProgress(
+            position = Duration.ZERO,
+            buffered = Duration.ZERO,
+            duration = target?.duration ?: Duration.ZERO,
+            episodeId = target?.id,
+        )
+    }
+
+    /**
+     * progress 를 발행하는 통로. 위치·길이와 그것이 속한 episodeId 를 한 번의 대입으로 묶는다.
+     *
+     * 구독자(재생 위치 저장 경로)는 이 쌍을 원자적으로 받아야 한다. 에피소드 id 를 별도 Flow 에서
+     * 가져오면 전환 순간 두 스트림의 지연 차 때문에 어긋난 쌍을 보게 되고, 이전 에피소드의
+     * 저장 위치가 오염된다. 새 발행 지점을 추가할 때도 반드시 이 함수를 거칠 것.
+     *
+     * 단일 항목 재생(`play(episode)`, `playClip`)과 `addTrack` 계열은 여기를 직접 거치지 않는다.
+     * 그 경로들은 transition 콜백이 대신 발행하며, 콜백도 이 함수를 거치므로 계약은 지켜진다.
+     * 목록을 통째로 갈아끼우는 경로만 콜백을 억제하고 확정값을 직접 발행한다.
+     */
+    private fun publishProgress(
+        position: Duration,
+        buffered: Duration,
+        duration: Duration,
+        episodeId: Long?,
+    ) {
+        _progress.value = Progress(
+            position = position,
+            buffered = buffered,
+            duration = duration,
+            episodeId = episodeId,
+        )
     }
 
     private val _nowPlaying = MutableStateFlow<Episode?>(null)
@@ -469,6 +593,13 @@ class PlayerDataSourceImpl @Inject constructor(
     }.flatMapLatest { (isPlaying, playback) ->
         flow {
             while (isPlaying) {
+                // 위치와 episodeId 를 반드시 같은 Main 블록 안에서 **읽는다**. transition 콜백도
+                // 같은 스레드에서 실행되므로, 이렇게 해야 둘이 서로 맞는 쌍이 된다.
+                // 블록 밖에서 읽으면 전환 도중의 어긋난 쌍이 만들어질 수 있다.
+                //
+                // 발행은 블록 밖(IO)에서 일어나므로 "읽기~발행" 사이에 전환이 끼어들 수 있다.
+                // 그래도 발행되는 쌍 자체는 일관되므로(이전 에피소드 + 그 에피소드의 실제 위치)
+                // 저장이 오염되지는 않는다. 잠깐 오래된 쌍이 보일 뿐이고 다음 tick 이 정정한다.
                 val progressValue = withContext(Dispatchers.Main) {
                     val duration = player.duration.toDurationMillis()
                     if (duration.isPositive()) {
@@ -476,12 +607,15 @@ class PlayerDataSourceImpl @Inject constructor(
                             position = player.currentPosition.toDurationMillis(),
                             buffered = player.bufferedPosition.toDurationMillis(),
                             duration = duration,
+                            episodeId = currentEpisodeId(),
                         )
                     } else {
                         null
                     }
                 }
-                progressValue?.let { _progress.value = it }
+                progressValue?.let {
+                    publishProgress(it.position, it.buffered, it.duration, it.episodeId)
+                }
                 delay(500L)
             }
 
@@ -493,12 +627,15 @@ class PlayerDataSourceImpl @Inject constructor(
                             position = duration,
                             buffered = duration,
                             duration = duration,
+                            episodeId = currentEpisodeId(),
                         )
                     } else {
                         null
                     }
                 }
-                progressValue?.let { _progress.value = it }
+                progressValue?.let {
+                    publishProgress(it.position, it.buffered, it.duration, it.episodeId)
+                }
             }
         }
     }

--- a/core/player/src/test/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImplTest.kt
+++ b/core/player/src/test/kotlin/io/jacob/episodive/core/player/datasource/PlayerDataSourceImplTest.kt
@@ -13,7 +13,9 @@ import androidx.media3.common.text.CueGroup
 import androidx.media3.exoplayer.ExoPlayer
 import app.cash.turbine.test
 import io.jacob.episodive.core.domain.download.EpisodeDownloader
+import io.jacob.episodive.core.model.mapper.toDurationMillis
 import io.jacob.episodive.core.testing.model.episodeTestData
+import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -22,11 +24,13 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import kotlin.time.Duration
 
 class PlayerDataSourceImplTest {
     private val player = mockk<ExoPlayer>(relaxed = true)
@@ -746,6 +750,90 @@ class PlayerDataSourceImplTest {
         dataSource.progress.test {
             val progress = awaitItem()
             assertEquals(episode.duration, progress.duration)
+            // T7 (C1/C2 회귀): transition 이 실은 progress 는 반드시 전환된 에피소드의 id 를
+            // 함께 싣고, 위치는 0 으로 리셋되어야 한다 (이전 에피소드의 위치가 새 에피소드로 새는 것 방지).
+            assertEquals(episode.id, progress.episodeId)
+            assertEquals(Duration.ZERO, progress.position)
+        }
+    }
+
+    @Test
+    fun `Given seek driven transition, When onMediaItemTransition invoked, Then progress position comes from player currentPosition`() = runTest {
+        // 탐색으로 항목이 바뀐 경우엔 플레이어가 이미 목표 위치에 가 있으므로 그 값을 싣는다.
+        // 여기서 0 을 하드코딩하면 방금 이동한 지점이 곧바로 0 으로 저장된다.
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(episode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episode)
+            .build()
+        every { player.currentMediaItemIndex } returns 0
+        every { player.currentPosition } returns 45_000L
+
+        // When
+        listenerSlot.captured.onMediaItemTransition(
+            mediaItem,
+            Player.MEDIA_ITEM_TRANSITION_REASON_SEEK,
+        )
+
+        // Then
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(45_000L.toDurationMillis(), progress.position)
+            assertEquals(episode.id, progress.episodeId)
+        }
+    }
+
+    @Test
+    fun `Given repeat transition, When onMediaItemTransition invoked, Then progress position is zero`() = runTest {
+        // 한 곡 반복도 같은 항목을 처음부터 다시 재생하므로 0 이 확정이다.
+        // AUTO 와 같은 분기를 공유하지만, 누군가 REPEAT 만 else 로 옮기면 잡아낸다.
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(episode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episode)
+            .build()
+        every { player.currentMediaItemIndex } returns 0
+        every { player.currentPosition } returns 3_500_000L
+
+        // When
+        listenerSlot.captured.onMediaItemTransition(
+            mediaItem,
+            Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT,
+        )
+
+        // Then
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(Duration.ZERO, progress.position)
+            assertEquals(episode.id, progress.episodeId)
+        }
+    }
+
+    @Test
+    fun `Given auto transition to next item, When onMediaItemTransition invoked, Then progress position is zero not the previous item position`() = runTest {
+        // 자동 전환은 새 항목을 처음부터 재생한다. 이 시점의 player.currentPosition 이 아직
+        // 이전 항목의 끝 위치일 수 있는데, 그 값을 새 에피소드에 실으면 듣지도 않은
+        // 에피소드가 사실상 완료 처리되어 이어듣기 지점이 사라진다.
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(episode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episode)
+            .build()
+        every { player.currentMediaItemIndex } returns 1
+        // 이전 항목의 끝 무렵 위치가 그대로 보이는 상황을 재현한다.
+        every { player.currentPosition } returns 3_500_000L
+
+        // When
+        listenerSlot.captured.onMediaItemTransition(
+            mediaItem,
+            Player.MEDIA_ITEM_TRANSITION_REASON_AUTO,
+        )
+
+        // Then
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(Duration.ZERO, progress.position)
+            assertEquals(episode.id, progress.episodeId)
         }
     }
 
@@ -852,5 +940,276 @@ class PlayerDataSourceImplTest {
 
         // Then
         dataSource.isPlaying.test { assertEquals(false, awaitItem()) }
+    }
+
+    // ---------------------------------------------------------------------
+    // C1~C4 회귀 테스트: 재생 위치 오염 방지
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `Given media3 fires transition inline inside setMediaItems, When prepare called, Then final progress keeps restored position and episodeId`() = runTest {
+        // Given: media3 1.8.0 은 setMediaItems 호출 스택 안에서 onMediaItemTransition 을
+        // 인라인 실행한다(C4). 그 콜백이 position 을 0 으로 덮은 뒤에도, prepare() 가 그 뒤에서
+        // 실제 복원 위치로 다시 확정해야 한다.
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(episode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episode)
+            .build()
+        every {
+            player.setMediaItems(any(), any<Int>(), any<Long>())
+        } answers {
+            listenerSlot.captured.onMediaItemTransition(
+                mediaItem,
+                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED,
+            )
+        }
+
+        // When
+        dataSource.prepare(listOf(episode), indexToPlay = 0, positionMs = 60_000L)
+
+        // Then
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(60_000L.toDurationMillis(), progress.position)
+            assertEquals(episode.id, progress.episodeId)
+        }
+    }
+
+    @Test
+    fun `Given media3 fires transition inline during prepare, When isPreparing guard is active, Then no progress is published mid setMediaItems callback`() = runTest {
+        // Given: (B) isPreparing 가드가 실제로 콜백 도중 발행을 막는지 직접 확인한다.
+        // progress 는 StateFlow 라 구독 시점에 따라(특히 단일 스레드 테스트 스케줄러에서는)
+        // 중간 방출이 컨플레이션으로 사라질 수 있다 — Turbine 으로 뒤늦게 구독하면 최종값만
+        // 보이는 게 그 예다. 대신 콜백이 실행되는 바로 그 순간의 값을 직접 스냅샷한다.
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(episode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episode)
+            .build()
+        var progressDuringCallback: io.jacob.episodive.core.model.Progress? = null
+        every {
+            player.setMediaItems(any(), any<Int>(), any<Long>())
+        } answers {
+            listenerSlot.captured.onMediaItemTransition(
+                mediaItem,
+                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED,
+            )
+            // isPreparing 가드가 없으면 이 시점에 이미 (episodeId=episode.id, position=0) 이
+            // 발행되어 있다 — Unconfined 로 즉시(비동기 스케줄링 없이) 현재 값을 읽는다.
+            progressDuringCallback = kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.Unconfined) {
+                dataSource.progress.first()
+            }
+        }
+
+        // When
+        dataSource.prepare(listOf(episode), indexToPlay = 0, positionMs = 60_000L)
+
+        // Then: 콜백이 실행되는 순간에는 아직 아무것도 발행되지 않아야 한다(episodeId=null 유지).
+        assertEquals(null, progressDuringCallback?.episodeId)
+
+        // 그리고 prepare() 가 끝난 뒤에는 복원 위치가 최종적으로 확정되어 있어야 한다.
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(60_000L.toDurationMillis(), progress.position)
+            assertEquals(episode.id, progress.episodeId)
+        }
+    }
+
+    @Test
+    fun `Given player duration is TIME_UNSET, When seekTo called, Then progress duration is not negative`() = runTest {
+        // Given
+        every { player.duration } returns C.TIME_UNSET
+        every { player.bufferedPosition } returns 0L
+
+        // When
+        dataSource.seekTo(1000L)
+
+        // Then
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(false, progress.duration.isNegative())
+        }
+    }
+
+    @Test
+    fun `Given player already holds a different episode, When rehydrate called, Then nowPlaying keeps the playing episode`() = runTest {
+        // Given: C3 회귀 방지. rehydrate 의 가드(player.currentMediaItem 기준)가 없으면
+        // 비동기 DB 복원값(A)이 실제로 재생 중인 B 를 밀어내고 nowPlaying 을 오염시킨다.
+        every { player.isPlaying } returns false
+        val otherEpisode = episode.copy(id = 999L)
+
+        // player.currentMediaItem 이 아직 비어 있는 상태에서 B 를 먼저 rehydrate 해
+        // nowPlaying 을 B 로 세팅한다.
+        dataSource.rehydrate(otherEpisode)
+
+        // 이제 플레이어가 실제로 B 를 들고 있는 상태를 재현한다.
+        val otherMediaItem = MediaItem.Builder()
+            .setMediaId(otherEpisode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(otherEpisode)
+            .build()
+        every { player.currentMediaItem } returns otherMediaItem
+
+        // When: 뒤늦게 도착한 A 로 rehydrate 를 시도한다.
+        dataSource.rehydrate(episode)
+
+        // Then: 가드가 없으면 nowPlaying 이 A 로 바뀐다 — 이 assert 가 그걸 잡아낸다.
+        dataSource.nowPlaying.test {
+            assertEquals(otherEpisode, awaitItem())
+        }
+    }
+
+    @Test
+    fun `Given nowPlaying rehydrated to A while player already holds B, When seekTo called, Then progress episodeId follows the player not nowPlaying`() = runTest {
+        // Given: C3 회귀 방지(교차 오염). rehydrate(A) 는 player.currentMediaItem 이 아직 비어
+        // 있을 때 허용되므로(가드를 통과) _nowPlaying 이 A 로 세팅될 수 있다. 그 직후 player 가
+        // 실제로는 B 를 들고 있는 상태(예: 비동기 전환 콜백이 아직 _nowPlaying 을 못 따라잡은 틈)를
+        // 재현한다. seekTo 가 _nowPlaying(=A) 대신 currentEpisodeId()(=B, player 기준) 를 써야만
+        // 위치가 B 의 것으로 정확히 저장된다.
+        every { player.isPlaying } returns false
+        every { player.bufferedPosition } returns 0L
+        every { player.duration } returns 600_000L
+        val otherEpisode = episode.copy(id = 999L)
+
+        // player.currentMediaItem 이 아직 비어 있는 상태에서 A 를 rehydrate 해 nowPlaying=A.
+        dataSource.rehydrate(episode)
+
+        // 실제로는 player 가 B 를 들고 있는 상태로 어긋난다(_nowPlaying 갱신 전).
+        val otherMediaItem = MediaItem.Builder()
+            .setMediaId(otherEpisode.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(otherEpisode)
+            .build()
+        every { player.currentMediaItem } returns otherMediaItem
+
+        // When
+        dataSource.seekTo(300_000L)
+
+        // Then: episodeId 가 nowPlaying(A) 이 아니라 실제로 player 가 들고 있는 B 여야 한다.
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(otherEpisode.id, progress.episodeId)
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 3차 수정 회귀 테스트: play/playClips isPreparing 가드 대칭 적용, seekTo duration 폴백
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `Given play list with non-first index, When setMediaItems fires inline transition, Then no emission carries first item id`() = runTest {
+        // Given: media3 는 1-인자 setMediaItems(list) 호출 스택 안에서도 목록 첫 항목에 대해
+        // onMediaItemTransition 을 인라인 실행한다. seekToDefaultPosition(indexToPlay) 로 목표에
+        // 도달하기 전이므로, 가드가 없으면 "재생하지도 않을 첫 항목(A) + 위치 0" 이 발행되어
+        // A 의 이어듣기 지점이 지워진다.
+        val episodeA = episodeTestDataList[0]
+        val episodeB = episodeTestDataList[1]
+        val itemA = MediaItem.Builder()
+            .setMediaId(episodeA.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episodeA)
+            .build()
+        every {
+            player.setMediaItems(any())
+        } answers {
+            listenerSlot.captured.onMediaItemTransition(
+                itemA,
+                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED,
+            )
+        }
+
+        // When / Then: play() 호출 전에 구독해 모든 방출을 수집한다.
+        dataSource.progress.test {
+            awaitItem() // 초기값
+
+            dataSource.play(episodes = listOf(episodeA, episodeB), indexToPlay = 1)
+
+            val emissions = cancelAndConsumeRemainingEvents()
+                .filterIsInstance<app.cash.turbine.Event.Item<io.jacob.episodive.core.model.Progress>>()
+                .map { it.value }
+
+            // 사용자가 요청한 것은 B 인데, 방출 중 A 의 id 가 실린 것이 하나라도 있으면
+            // A 의 이어듣기 지점이 지워진다.
+            assertEquals(false, emissions.any { it.episodeId == episodeA.id })
+
+            val last = emissions.last()
+            assertEquals(episodeB.id, last.episodeId)
+            assertEquals(Duration.ZERO, last.position)
+        }
+    }
+
+    @Test
+    fun `Given playClips with non-first index, When setMediaItems fires inline transition, Then no emission carries first item id`() = runTest {
+        // playClips 도 play(episodes, indexToPlay) 와 같은 가드를 적용받아야 한다.
+        val episodeA = episodeTestDataList[0]
+        val episodeB = episodeTestDataList[1]
+        val itemA = MediaItem.Builder()
+            .setMediaId(episodeA.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episodeA)
+            .build()
+        every {
+            player.setMediaItems(any())
+        } answers {
+            listenerSlot.captured.onMediaItemTransition(
+                itemA,
+                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED,
+            )
+        }
+
+        dataSource.progress.test {
+            awaitItem() // 초기값
+
+            dataSource.playClips(episodes = listOf(episodeA, episodeB), indexToPlay = 1)
+
+            val emissions = cancelAndConsumeRemainingEvents()
+                .filterIsInstance<app.cash.turbine.Event.Item<io.jacob.episodive.core.model.Progress>>()
+                .map { it.value }
+
+            assertEquals(false, emissions.any { it.episodeId == episodeA.id })
+
+            val last = emissions.last()
+            assertEquals(episodeB.id, last.episodeId)
+            assertEquals(Duration.ZERO, last.position)
+        }
+    }
+
+    @Test
+    fun `Given progress still carries the previous episode's duration, When seekTo called on the new episode with unset player duration, Then progress duration falls back to the new episode's duration`() = runTest {
+        // Given: A 에서 B 로 전환된 직후. player.duration 은 아직 TIME_UNSET 이고, _progress 에는
+        // 직전 A 의 duration 이 남아 있다. 이때 _progress.value.duration 으로 폴백하면 A 의 짧은/긴
+        // duration 이 그대로 B 에 실려, 짧은 길이 + 큰 위치 조합이 완료 판정을 잘못 뒤집는다.
+        val episodeA = episodeTestDataList[0]
+        val episodeB = episodeTestDataList[1]
+        check(episodeA.duration != episodeB.duration) { "테스트 데이터의 duration 이 같으면 폴백 오류를 구분할 수 없다" }
+
+        // A 로 전환되어 _progress.duration 이 A 의 길이로 채워진 상태를 만든다.
+        val itemA = MediaItem.Builder()
+            .setMediaId(episodeA.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episodeA)
+            .build()
+        every { player.currentMediaItemIndex } returns 0
+        listenerSlot.captured.onMediaItemTransition(itemA, Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
+
+        // 이제 플레이어는 실제로 B 를 들고 있고, 아직 prepare 전이라 duration 이 TIME_UNSET 이다.
+        val itemB = MediaItem.Builder()
+            .setMediaId(episodeB.id.toString())
+            .setUri(mockk<Uri>(relaxed = true))
+            .setTag(episodeB)
+            .build()
+        every { player.currentMediaItem } returns itemB
+        every { player.duration } returns C.TIME_UNSET
+        every { player.bufferedPosition } returns 0L
+
+        // When
+        dataSource.seekTo(1000L)
+
+        // Then
+        dataSource.progress.test {
+            val progress = awaitItem()
+            assertEquals(episodeB.duration, progress.duration)
+        }
     }
 }

--- a/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/kotlin/io/jacob/episodive/feature/player/PlayerViewModel.kt
@@ -72,13 +72,6 @@ class PlayerViewModel @Inject constructor(
             initialValue = null
         )
 
-    private val playingEpisode = combine(
-        nowPlaying,
-        playerRepository.progress,
-    ) { episode, progress ->
-        episode?.id to progress
-    }
-
     private val podcast = nowPlaying
         .mapNotNull { it?.feedId }
         .distinctUntilChanged()
@@ -140,12 +133,20 @@ class PlayerViewModel @Inject constructor(
 
     init {
         handleActions()
+        // 저장 키를 progress 자신이 들고 있는 episodeId 에서만 가져온다.
+        // DB 파생 nowPlaying 과 combine 하면 에피소드 전환 순간 두 스트림의 지연 차 때문에
+        // "이전 에피소드 + 새 위치" 쌍이 저장되어 이전 에피소드의 이어듣기 지점이 오염된다.
+        // collectLatest 가 아니라 collect 인 이유: 전환 직전 tick 의 쓰기가 취소되면
+        // 그 에피소드의 마지막 몇 초가 유실되어 이어듣기 지점이 뒤로 밀린다.
+        // upsert 한 건짜리 저렴한 쓰기이므로 취소하지 않고 끝까지 보낸다.
         viewModelScope.launch {
-            playingEpisode.collectLatest { (episodeId, progress) ->
-                if (episodeId != null) {
-                    updatePlayedEpisodeUseCase(episodeId, progress)
+            playerRepository.progress
+                .distinctUntilChanged()
+                .collect { progress ->
+                    progress.episodeId?.let { episodeId ->
+                        updatePlayedEpisodeUseCase(episodeId, progress)
+                    }
                 }
-            }
         }
         viewModelScope.launch {
             getUserDataUseCase()
@@ -164,27 +165,39 @@ class PlayerViewModel @Inject constructor(
         }
         viewModelScope.launch {
             var lastSavedTime = 0L
-            combineTyped(
-                playerRepository.nowPlaying,
+            var lastSavedEpisodeId: Long? = null
+            var lastSavedPositionMs = 0L
+            // 저장 위치와 마찬가지로 세션 스냅샷의 에피소드도 progress 에서 가져온다.
+            // 별도 nowPlaying 과 묶으면 콜드스타트 직후 "직전 에피소드 + 위치 0" 이 저장되어
+            // DataStore 의 마지막 재생 지점까지 0 으로 덮인다.
+            combine(
                 playerRepository.indexOfList,
                 playerRepository.progress,
                 playerRepository.isShuffle,
                 playerRepository.repeat,
-            ) { nowPlaying: Episode?, index: Int, progress: Progress, shuffle: Boolean, repeat: Repeat ->
-                if (nowPlaying != null) {
+            ) { index: Int, progress: Progress, shuffle: Boolean, repeat: Repeat ->
+                progress.episodeId?.let { episodeId ->
                     LastPlaySnapshot(
-                        episodeId = nowPlaying.id,
+                        episodeId = episodeId,
                         index = index,
                         positionMs = progress.position.inWholeMilliseconds,
                         shuffle = shuffle,
                         repeat = repeat,
                     )
-                } else null
+                }
             }
                 .filterNotNull()
                 .collectLatest { snapshot ->
                     val now = timeProvider.currentTimeMillis()
-                    if (now - lastSavedTime >= 5_000) {
+                    // 에피소드가 바뀌면 5초 창을 기다리지 않는다. 기다리면 전환 직후 한 번 저장된 값이
+                    // 창이 닫힌 동안 갱신되지 않아, 그 사이 앱이 죽으면 엉뚱한 지점부터 복원된다.
+                    val episodeChanged = snapshot.episodeId != lastSavedEpisodeId
+                    // 위치가 뒤로 갔다면 사용자가 되감은 것이다. 재생 중에는 위치가 늘기만 하므로
+                    // 재생 중에는 위치가 늘기만 하므로 이 조건은 탐색이나 반복 재생에서만 성립한다.
+                    // 창을 기다리다 그 사이 일시정지하면 progress
+                    // 방출이 멈춰 되감기 이전 값이 스냅샷에 남고, 다음 실행에서 되살아난다.
+                    val rewound = snapshot.positionMs < lastSavedPositionMs
+                    if (episodeChanged || rewound || now - lastSavedTime >= 5_000) {
                         saveLastPlayStateUseCase(
                             episodeId = snapshot.episodeId,
                             index = snapshot.index,
@@ -193,6 +206,8 @@ class PlayerViewModel @Inject constructor(
                             repeat = snapshot.repeat,
                         )
                         lastSavedTime = now
+                        lastSavedEpisodeId = snapshot.episodeId
+                        lastSavedPositionMs = snapshot.positionMs
                     }
                 }
         }
@@ -358,17 +373,16 @@ class PlayerViewModel @Inject constructor(
         sleepTimerJob = viewModelScope.launch {
             try {
                 playerRepository.setVolume(1f)
-                val startEpisodeId = nowPlaying.value?.id ?: return@launch
-                val duration = playerRepository.progress.first().duration.inWholeMilliseconds
-                if (duration <= 0) return@launch
+                // 여기서도 에피소드 판별을 progress 안의 episodeId 로 한다.
+                // DB 파생 nowPlaying 과 섞으면 전환 시점에 타이머가 엉뚱한 에피소드를 기준으로 돈다.
+                val current = playerRepository.progress.first()
+                val startEpisodeId = current.episodeId ?: return@launch
+                if (current.duration.inWholeMilliseconds <= 0) return@launch
 
                 var timerExpired = false
-                combine(playerRepository.progress, nowPlaying) { progress, episode ->
-                    progress to episode
-                }.takeWhile { (progress, episode) ->
+                playerRepository.progress.takeWhile { progress ->
                     val remaining = progress.duration.inWholeMilliseconds - progress.position.inWholeMilliseconds
-                    val sameEpisode = episode?.id == startEpisodeId
-                    if (!sameEpisode) return@takeWhile false
+                    if (progress.episodeId != startEpisodeId) return@takeWhile false
                     _sleepTimerRemainingMs.value = remaining.coerceAtLeast(0)
                     if (remaining <= FADE_OUT_DURATION_MS) {
                         val volume = remaining.toFloat() / FADE_OUT_DURATION_MS

--- a/feature/player/src/test/kotlin/io/jacob/episodive/feature/player/PlayerViewModelTest.kt
+++ b/feature/player/src/test/kotlin/io/jacob/episodive/feature/player/PlayerViewModelTest.kt
@@ -439,7 +439,247 @@ class PlayerViewModelTest {
             coVerify(exactly = 0) { restoreLastPlayStateUseCase() }
         }
 
+    // --- Played Progress Persistence Tests ---
+
+    @Test
+    fun `Given episode A mid-playback, When progress flips to episode B with stale zero position, Then episode A is not saved with zero position`() =
+        runTest {
+            setupDefaultMocks()
+            val episodeA = episodeTestDataList[0]
+            val episodeB = episodeTestDataList[1]
+            nowPlayingFlow.value = episodeA
+            // getNowPlayingUseCase 는 DB 왕복 지연을 재현하기 위해 계속 A 를 방출한다.
+            every { getNowPlayingUseCase() } returns flowOf(episodeA)
+            progressFlow.value = Progress(500.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            // 에피소드 전환 순간: progress 는 이미 B 를 가리키지만 nowPlaying(DB 파생)은 아직 A 를 방출 중
+            progressFlow.value = Progress(0.seconds, 0.seconds, 0.seconds, episodeId = episodeB.id)
+
+            coVerify(exactly = 0) {
+                updatePlayedEpisodeUseCase(episodeA.id, match { it.position == 0.seconds })
+            }
+            coVerify {
+                updatePlayedEpisodeUseCase(episodeB.id, match { it.position == 0.seconds })
+            }
+        }
+
+    @Test
+    fun `Given episode A mid-playback, When switching to episode B resume position, Then episode A is not saved with episode B position`() =
+        runTest {
+            setupDefaultMocks()
+            val episodeA = episodeTestDataList[0]
+            val episodeB = episodeTestDataList[1]
+            nowPlayingFlow.value = episodeA
+            every { getNowPlayingUseCase() } returns flowOf(episodeA)
+            progressFlow.value = Progress(500.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            // 이어듣기 전환: ZERO 방출이 StateFlow conflation 으로 생략된 상태를 재현
+            progressFlow.value = Progress(300.seconds, 0.seconds, 0.seconds, episodeId = episodeB.id)
+
+            coVerify(exactly = 0) {
+                updatePlayedEpisodeUseCase(episodeA.id, match { it.position == 300.seconds })
+            }
+            coVerify {
+                updatePlayedEpisodeUseCase(episodeB.id, match { it.position == 300.seconds })
+            }
+        }
+
+    @Test
+    fun `Given cold start with nowPlaying restored but progress not yet rehydrated, When ViewModel is created, Then no save is invoked`() =
+        runTest {
+            setupDefaultMocks()
+            val episodeA = episodeTestData
+            nowPlayingFlow.value = episodeA
+            every { getNowPlayingUseCase() } returns flowOf(episodeA)
+            // progressFlow 는 초기값 그대로: episodeId = null (rehydrate 는 progress 를 건드리지 않는다)
+
+            createViewModel()
+
+            coVerify(exactly = 0) { updatePlayedEpisodeUseCase(any(), any()) }
+        }
+
+    @Test
+    fun `Given episode A rewound to zero, When user restarts from the beginning, Then position zero is saved`() =
+        runTest {
+            // 사용자가 맨 앞으로 되감거나 완료한 에피소드를 다시 듣기 시작하면 0 이 저장되어야 한다.
+            // position==0 저장을 막는 가드를 넣으면 이 테스트가 실패한다.
+            setupDefaultMocks()
+            val episodeA = episodeTestData
+            nowPlayingFlow.value = episodeA
+            every { getNowPlayingUseCase() } returns flowOf(episodeA)
+            progressFlow.value = Progress(500.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            progressFlow.value = Progress(0.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            coVerify {
+                updatePlayedEpisodeUseCase(episodeA.id, match { it.position == 0.seconds })
+            }
+        }
+
+    @Test
+    fun `Given progress without episodeId, When ViewModel is created, Then LastPlaySnapshot is not saved`() =
+        runTest {
+            setupDefaultMocks()
+            every { timeProvider.currentTimeMillis() } returns 10_000L
+            // nowPlaying 은 채워져 있지만 progress.episodeId 만 null 인 상태를 재현한다.
+            // 옛 5-arity combine(index, progress, shuffle, repeat, nowPlaying) 으로 되돌리면
+            // nowPlaying 이 non-null 이라 이 테스트가 실패해야 한다. nowPlaying 을 세팅하지 않으면
+            // 옛 구현도 nowPlaying==null 때문에 저장을 건너뛰어 이 테스트가 실효 없이 통과해버린다.
+            nowPlayingFlow.value = episodeTestData
+            progressFlow.value = Progress(100.seconds, 0.seconds, 0.seconds, episodeId = null)
+
+            createViewModel()
+
+            coVerify(exactly = 0) {
+                saveLastPlayStateUseCase(any(), any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `Given progress with episodeId, When ViewModel is created, Then LastPlaySnapshot is saved with progress episodeId`() =
+        runTest {
+            setupDefaultMocks()
+            every { timeProvider.currentTimeMillis() } returns 10_000L
+            val episodeA = episodeTestData
+            progressFlow.value = Progress(100.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            coVerify {
+                saveLastPlayStateUseCase(episodeA.id, any(), 100_000L, any(), any())
+            }
+        }
+
+    @Test
+    fun `Given episode changes within the 5-second throttle window, When progress flips to episode B, Then both episodes are saved without waiting`() =
+        runTest {
+            setupDefaultMocks()
+            // 시각을 고정해 throttle 창(5초)이 절대 열리지 않게 한다.
+            // 그럼에도 에피소드가 바뀌면 lastSavedEpisodeId 가드가 즉시 저장을 강제해야 한다.
+            every { timeProvider.currentTimeMillis() } returns 10_000L
+            val episodeA = episodeTestDataList[0]
+            val episodeB = episodeTestDataList[1]
+            progressFlow.value = Progress(100.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            // B 의 위치를 A 보다 **크게** 잡는 것이 중요하다. 작게 잡으면 rewound 가드가 참이 되어
+            // episodeChanged 를 지워도 저장이 일어나고, 이 테스트는 아무것도 잡지 못한다.
+            progressFlow.value = Progress(200.seconds, 0.seconds, 0.seconds, episodeId = episodeB.id)
+
+            coVerify {
+                saveLastPlayStateUseCase(episodeA.id, any(), 100_000L, any(), any())
+            }
+            coVerify {
+                saveLastPlayStateUseCase(episodeB.id, any(), 200_000L, any(), any())
+            }
+        }
+
+    @Test
+    fun `Given same episode progress ticks within the 5-second throttle window, When position changes, Then only one snapshot is saved`() =
+        runTest {
+            setupDefaultMocks()
+            // 계약 테스트: throttle 을 통째로 없애면(예: episodeChanged 가드만 남기고 시간 체크를 지우면)
+            // 같은 에피소드 안에서도 매 tick 저장이 발생해 이 테스트가 실패해야 한다.
+            every { timeProvider.currentTimeMillis() } returns 10_000L
+            val episodeA = episodeTestDataList[0]
+            progressFlow.value = Progress(100.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            progressFlow.value = Progress(200.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            coVerify(exactly = 1) {
+                saveLastPlayStateUseCase(episodeA.id, any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `Given user rewinds within the 5-second throttle window, When position jumps backward, Then the rewound position is saved immediately`() =
+        runTest {
+            // 되감기는 throttle 을 기다리면 안 된다. 창이 닫힌 동안 사용자가 일시정지하면
+            // progress 방출이 멈춰 되감기 이전 값이 스냅샷에 남고, 다음 실행에서 그 값으로 복원된다.
+            // 되감은 지점이 사라지는 것은 사용자에겐 "내가 한 조작이 무시됐다" 로 보인다.
+            // rewound 가드를 지우면 이 테스트가 실패한다.
+            setupDefaultMocks()
+            every { timeProvider.currentTimeMillis() } returns 10_000L
+            val episodeA = episodeTestDataList[0]
+            progressFlow.value = Progress(1800.seconds, 0.seconds, 3600.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            // 사용자가 맨 앞으로 되감았다. 시각은 그대로라 throttle 창은 닫혀 있다.
+            progressFlow.value = Progress(0.seconds, 0.seconds, 3600.seconds, episodeId = episodeA.id)
+
+            coVerify(exactly = 1) {
+                saveLastPlayStateUseCase(episodeA.id, any(), 0L, any(), any())
+            }
+        }
+
+    @Test
+    fun `Given episode A progress ticks consecutively, When collected, Then the last position is persisted`() =
+        runTest {
+            // 같은 에피소드 안에서 연속 방출된 tick 중 마지막 값이 저장되는지 확인한다.
+            //
+            // 주의: 이 테스트는 collect 와 collectLatest 를 구별하지 못한다. MainDispatcherRule 의
+            // UnconfinedTestDispatcher 에서는 두 구현이 똑같이 동작하기 때문이다(실측 확인).
+            // 저장 콜렉터를 collectLatest 로 되돌려도 이 테스트는 통과한다 —
+            // "느린 DB 에서 전환 직전 쓰기가 취소되지 않는다" 는 보장은 여기서 검증되지 않는다.
+            setupDefaultMocks()
+            val episodeA = episodeTestDataList[0]
+            progressFlow.value = Progress(100.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            createViewModel()
+
+            progressFlow.value = Progress(200.seconds, 0.seconds, 0.seconds, episodeId = episodeA.id)
+
+            coVerify {
+                updatePlayedEpisodeUseCase(episodeA.id, match { it.position == 200.seconds })
+            }
+        }
+
     // --- Sleep Timer Tests ---
+
+    @Test
+    fun `Given end of episode timer running, When progress moves to another episode, Then timer stops without pausing`() =
+        runTest {
+            // 타이머의 에피소드 판별도 progress.episodeId 로 한다. nowPlaying 은 DB 왕복 탓에
+            // 전환 후에도 한동안 이전 에피소드로 남아 있어서, 그것으로 판별하면 타이머가
+            // 이미 넘어간 에피소드를 기준으로 계속 돌며 엉뚱한 시점에 재생을 멈춘다.
+            // 판별을 nowPlaying 으로 되돌리면 이 테스트가 실패한다.
+            setupDefaultMocks()
+            val episodeA = episodeTestDataList[0]
+            val episodeB = episodeTestDataList[1]
+            // nowPlaying 은 A 로 고정한다 — 전환이 progress 에만 먼저 반영된 상태를 재현한다.
+            nowPlayingFlow.value = episodeA
+            every { getNowPlayingUseCase() } returns flowOf(episodeA)
+            progressFlow.value = Progress(10.seconds, 10.seconds, 600.seconds, episodeId = episodeA.id)
+
+            val viewModel = createViewModel()
+            viewModel.sendAction(PlayerAction.SleepTimerEndOfEpisode)
+
+            // 아직 A 를 재생 중이므로 타이머가 살아 있다.
+            progressFlow.value = Progress(20.seconds, 20.seconds, 600.seconds, episodeId = episodeA.id)
+            verify(exactly = 0) { playerRepository.pause() }
+
+            // B 로 넘어가면 타이머는 중단돼야 한다.
+            // 남은 시간을 **0 으로** 주는 것이 중요하다. 만료 조건(remaining <= 500)을 넘기지 않으면
+            // 판별을 무엇으로 하든 pause() 가 불리지 않아 이 테스트가 아무것도 잡지 못한다.
+            //
+            // 다만 이 테스트는 "판별을 nowPlaying 으로 되돌리면 실패한다"를 보이지는 못한다.
+            // nowPlaying 은 stateIn(WhileSubscribed) 이라 이 테스트에서 값이 흐르지 않고,
+            // 옛 구현도 null 비교로 조기 중단되기 때문이다(실측 확인).
+            // 잡아내는 것은 "에피소드 판별을 아예 없애는" 회귀다.
+            progressFlow.value = Progress(600.seconds, 600.seconds, 600.seconds, episodeId = episodeB.id)
+
+            verify(exactly = 0) { playerRepository.pause() }
+        }
 
     @Test
     fun `Given SetSleepTimer action, When timer expires, Then pause is called and SleepTimerExpired effect is emitted`() =
@@ -507,7 +747,9 @@ class PlayerViewModelTest {
         runTest {
             setupDefaultMocks()
             nowPlayingFlow.value = episodeTestData
-            progressFlow.value = Progress(0.seconds, 0.seconds, 0.seconds)
+            // episodeId 를 채워서 조기 return(episodeId == null) 이 아니라
+            // duration == 0(라이브 스트림) 때문에 타이머가 뜨지 않는 경로를 실제로 검증한다.
+            progressFlow.value = Progress(0.seconds, 0.seconds, 0.seconds, episodeId = episodeTestData.id)
 
             val viewModel = createViewModel()
 


### PR DESCRIPTION
## 변경 사항

들었던 에피소드의 재생 위치가, 다른 에피소드를 재생하는 순간 사라지는 문제를 고쳤습니다.

### 원인

재생 위치를 저장할 때 **키와 값의 출처가 달랐습니다.** `PlayerViewModel`이 에피소드 id는 `nowPlaying`(Room 왕복 + `flowOn(IO)` + `stateIn`)에서, 위치는 `progress`(StateFlow 직결)에서 가져와 `combine`했습니다. 전환 순간 위치만 먼저 도착해 `(이전 에피소드, 새 위치)` 쌍이 만들어지고, 가드 없이 그대로 저장됐습니다.

여기서 네 증상이 갈라졌고 모두 실행으로 재현했습니다.

| | 증상 |
|---|---|
| C1 | 다른 에피소드를 재생하면 이전 것이 0으로 (combine 방출 80/80 재현) |
| C2 | 이어듣기로 전환하면 이전 것에 **새 에피소드의 위치**가 기록 (0이 아닌 오염) |
| C3 | 콜드스타트에서 아무 조작 없이도 덮어써짐 — 레이스가 아니라 **매 실행 결정적** |
| C4 | 세션 복원 시 media3가 `setMediaItems` 안에서 **인라인 실행**하는 콜백이 복원 위치를 0으로 덮음 |

### 해결

**위치와 그 위치의 주인을 한 값으로 묶었습니다.** `Progress`에 `episodeId`를 싣고, 발행은 `publishProgress()`를 거치며, 저장 경로는 `progress` 하나만 구독합니다. id를 별도 스트림에서 가져오는 한 두 스트림의 지연 차는 원리적으로 남습니다.

| 파일 | 변경 |
|---|---|
| `core/model/Progress.kt` | `episodeId: Long? = null` — null은 "재생 대상 미확정", 저장하지 않음 |
| `core/player/PlayerDataSourceImpl.kt` | 발행 통로 단일화, `isPreparing` 가드(목록 교체 중 잘못된 중간값 차단), `episodeId`를 플레이어의 실제 항목에서 유도, 전환 사유별 위치 결정 |
| `feature/player/PlayerViewModel.kt` | 저장 경로에서 DB 파생 `nowPlaying` 제거, 스냅샷 throttle을 에피소드·되감기 인지형으로 |
| `core/domain/RestoreLastPlayStateUseCase.kt` | 복원 위치를 항상 "그 에피소드 자신의" 것으로 |
| `CLAUDE.md` | 재생 위치 저장 규약 문서화 |

### 하지 않은 것

`position == 0이면 저장 안 함` 같은 가드는 **쓰지 않았습니다.** "맨 앞으로 되감기"와 "완료 후 처음부터 다시 듣기"가 0을 저장해야 정상이고, C2(0이 아닌 오염)는 그 가드로 잡히지도 않습니다. 대신 두 동작을 지키는 계약 테스트를 넣었습니다.

## 테스트

`./gradlew test lint` 통과. 회귀 테스트 20여 개 추가.

**프로덕션 코드를 한 줄씩 되돌려 실패를 확인한 것이 15건입니다.** 이 과정에서 "되돌려도 통과하는" 무의미한 테스트 네 개를 찾아 교체했고, 사실이 아닌 주석도 정정했습니다. 여전히 회귀를 잡지 못하는 항목(디스패처 특성상 `collect`/`collectLatest`를 구별할 수 없는 경우 등)은 테스트 주석에 그 사실을 명시했습니다.

### 에뮬레이터 QA (Pixel, API 36)

DB(`played_episodes`)를 직접 조회해 확인했습니다.

| 시나리오 | 결과 |
|---|---|
| A를 20:49까지 듣고 → B 재생 | A=1263초 **유지** (0으로도, B 위치로도 안 덮임) |
| 목록 세 번째 항목 재생 | 첫·두 번째 항목 **기록 없음** (오염 없음) |
| 강제 종료 → 재실행, 무조작 12초 | B=350초 **유지** |
| 세션 복원 정확도 | 이어듣기가 **6:00에서 재개** (되감김 없음) |
| 6:00에서 맨 앞 되감기 → 즉시 종료 | 21초로 **유지** (5초 창에 갇히지 않음) |

## 알려진 한계

- **이미 0으로 깎인 기존 데이터는 복구할 수 없습니다.** 원래 위치를 어디에도 남겨두지 않았습니다. 앞으로 재생하는 것부터 정상 동작합니다.
- 플레이어 유닛 테스트는 mockk ExoPlayer 위에서 돌아 media3의 실제 콜백 타이밍을 보증하지 않습니다. 검증 과정에서 Robolectric으로 실제 ExoPlayer 1.8.0을 띄워 대조했지만 그 프로브는 저장소에 남기지 않았습니다.

## 범위 밖 (별도 이슈 권장)

둘 다 "저장된 게 사라진다"가 아니라 **제품 동작 결정**이라 분리했습니다.

- 재생목록에서 `다음/이전`으로 이동할 때 그 항목의 저장 위치를 복원하지 않음
- 팟캐스트 상세·검색에서 재생할 때 이어듣기 위치를 복원하지 않음 (`ResumeEpisodeUseCase`를 쓰는 곳은 홈 이어듣기·보관함뿐)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDQXBdahZYSRWZzoc81syP