### PR TITLE
fix: 이어듣기 카드 진행바가 남은 시간 표기에 따라 출렁이는 문제

### DIFF
--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
@@ -52,6 +53,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
@@ -402,6 +404,13 @@ private val HomeHeroPadding = 14.dp
 private const val HomeHeroCoverSizeDp = 60
 private val HomeHeroCoverSize = HomeHeroCoverSizeDp.dp
 
+/**
+ * 이어듣기 카드에서 남은 시간 라벨이 차지할 수 있는 최대 폭. 진행바가 `weight` 로 나머지를 먹으므로
+ * 상한이 없으면 큰 글꼴 설정에서 라벨이 줄을 다 차지하고 진행바가 0 폭으로 사라진다. 좁은 화면
+ * (320dp)에서도 진행바에 절반 가까이 남도록 잡은 값이다.
+ */
+private val HomeHeroRemainLabelMaxWidth = 120.dp
+
 @Composable
 private fun HomeHeader(
     modifier: Modifier = Modifier,
@@ -476,6 +485,7 @@ private fun HomeContinueListeningHero(
     onClick: () -> Unit,
 ) {
     val dimension = LocalDimensionTheme.current
+    val density = LocalDensity.current
     val remain = episode.remain
     val leftLabel = stringResource(uiR.string.core_ui_left)
 
@@ -483,6 +493,15 @@ private fun HomeContinueListeningHero(
     // 재생 여부를 함께 본다 — 이어듣기 목록에는 방금 튼 것도 있어, 어느 것이 실제로 울리고
     // 있는지가 라벨 없이는 드러나지 않는다.
     val isNowPlaying = episode.id == LocalNowPlayingEpisodeId.current && LocalIsPlaying.current
+
+    // 남은 시간 표기는 "5분 1초" → "5분" 처럼 항목이 통째로 빠지며 폭이 줄어든다. 그 자리를
+    // 매번 다시 재면 나머지를 weight 로 먹는 진행바가 같이 늘었다 줄었다 하며 재생 내내
+    // 출렁인다. 한 번 잡은 폭을 최대치로 붙들어 진행바 폭을 고정한다.
+    //
+    // 되감기처럼 표기가 되레 길어지는 경로에서는 폭이 한 번 넓어지고 그대로 유지된다 — 그 뒤로
+    // 진행바가 조금 좁아진 채 있지만, 매초 출렁이는 것보다는 낫다는 판단이다. 폭 자체는
+    // [HomeHeroRemainLabelMaxWidth] 로 막혀 있어 진행바가 사라지는 데까지 가지는 않는다.
+    var remainLabelWidth by remember(episode.id) { mutableStateOf(0.dp) }
 
     // 카드 배경은 이 에피소드 커버에서 뽑은 색으로 흐른다. 팔레트가 준비되기 전에는
     // 기존 브랜드 그라디언트를 그대로 쓴다.
@@ -568,12 +587,27 @@ private fun HomeContinueListeningHero(
                 )
 
                 Text(
+                    modifier = Modifier
+                        .widthIn(
+                            min = remainLabelWidth,
+                            max = HomeHeroRemainLabelMaxWidth,
+                        )
+                        .onSizeChanged { size ->
+                            val width = with(density) { size.width.toDp() }
+                            if (width > remainLabelWidth) remainLabelWidth = width
+                        },
                     // 목록 행과 같은 표기를 쓴다. 분 단위로 직접 만들면 로케일이 안 붙고
                     // 1분 미만이 "0분 남음"이 된다.
                     text = remain?.let { "${it.toHumanReadable()} $leftLabel" }.orEmpty(),
                     style = MaterialTheme.typography.bodySmall,
                     color = Color.White.copy(alpha = 0.7f),
                     maxLines = 1,
+                    // 상한에 걸린 표기는 잘린다. 기본값 Clip 은 글자를 반 토막 내므로 잘렸다는
+                    // 사실이 드러나는 말줄임을 쓴다.
+                    overflow = TextOverflow.Ellipsis,
+                    // 자리를 붙들어 두면 짧아진 표기가 그 안에서 왼쪽으로 쏠린다. 카드 오른쪽
+                    // 가장자리에 맞춰 두려면 끝 정렬이어야 한다.
+                    textAlign = TextAlign.End,
                 )
             }
         }

--- a/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeScreenTest.kt
+++ b/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeScreenTest.kt
@@ -1,12 +1,18 @@
 package io.jacob.episodive.feature.home
 
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.Dp
 import io.jacob.episodive.core.designsystem.theme.EpisodiveTheme
 import io.jacob.episodive.core.model.Channel
 import io.jacob.episodive.core.model.Episode
@@ -21,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)
 class HomeScreenTest {
@@ -45,11 +52,14 @@ class HomeScreenTest {
         onPodcastClick: (Long) -> Unit = {},
         onChannelClick: (Long) -> Unit = {},
         onMoreClick: (HomeSection) -> Unit = {},
+        // 이어듣기 목록을 화면이 뜬 뒤에 바꿔야 하는 테스트를 위한 통로. 주면 [playingEpisodes]
+        // 대신 이 상태를 읽어, 값을 바꾸는 것만으로 카드가 다시 그려진다.
+        playingEpisodesState: State<List<Episode>>? = null,
     ) {
         composeTestRule.setContent {
             EpisodiveTheme {
                 HomeScreen(
-                    playingEpisodes = playingEpisodes,
+                    playingEpisodes = playingEpisodesState?.value ?: playingEpisodes,
                     userRecentPodcasts = userRecentPodcasts,
                     randomEpisodes = randomEpisodes,
                     userTrendingPodcasts = userTrendingPodcasts,
@@ -574,5 +584,49 @@ class HomeScreenTest {
         composeTestRule.onNodeWithText("My recent published").assertDoesNotExist()
         composeTestRule.onNodeWithText("Random episodes").assertDoesNotExist()
         composeTestRule.onNodeWithText("Channels worth listening to").assertDoesNotExist()
+    }
+
+    // --- 이어듣기 카드 진행바 ---
+
+    @Test
+    fun continueListeningHero_progressBarKeepsWidthWhenRemainLabelShrinks() {
+        // 남은 시간 표기는 "5min 1sec Left" → "5min Left" 처럼 항목이 통째로 빠지며 좁아진다.
+        // 그 자리를 매번 다시 재면 나머지를 weight 로 먹는 진행바가 함께 늘었다 줄었다 하며
+        // 재생 내내 출렁인다.
+        val base = episodeTestDataList.first()
+        val duration = requireNotNull(base.duration)
+        val playingEpisodes = mutableStateOf(listOf(base.copy(position = duration - 301.seconds)))
+
+        // 다른 섹션을 모두 비워 화면 안의 진행바가 이 카드의 것 하나뿐이게 만든다 —
+        // [continueListeningProgressBarWidth] 가 그 유일성에 기댄다.
+        setHomeScreen(
+            userRecentPodcasts = emptyList(),
+            randomEpisodes = emptyList(),
+            userTrendingPodcasts = emptyList(),
+            followedPodcasts = emptyList(),
+            localTrendingPodcasts = emptyList(),
+            foreignTrendingPodcasts = emptyList(),
+            liveEpisodes = emptyList(),
+            channels = emptyList(),
+            playingEpisodesState = playingEpisodes,
+        )
+
+        composeTestRule.onNodeWithText("5min 1sec Left").assertExists()
+        val widthBefore = continueListeningProgressBarWidth()
+
+        composeTestRule.runOnIdle {
+            playingEpisodes.value = listOf(base.copy(position = duration - 300.seconds))
+        }
+
+        composeTestRule.onNodeWithText("5min Left").assertExists()
+        assertEquals(widthBefore, continueListeningProgressBarWidth())
+    }
+
+    private fun continueListeningProgressBarWidth(): Dp {
+        val bounds = composeTestRule
+            .onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .getUnclippedBoundsInRoot()
+
+        return bounds.right - bounds.left
     }
 }


### PR DESCRIPTION
## 변경 사항

- 홈 상단 이어듣기 카드에서 진행바와 남은 시간 라벨이 한 `Row` 에 있고, 진행바가 `weight(1f)` 로 나머지를 먹는다. 남은 시간 표기는 `Duration.toHumanReadable()` 이 만드는데 `"5분 1초"` → `"5분"` 처럼 항목이 통째로 빠지며 좁아진다. 그만큼 진행바가 늘어나 재생 내내 매초 폭이 흔들렸다 — 실측으로 166dp ↔ 171dp 를 오갔다.
- 라벨 폭을 한 번 잡히면 줄지 않게 붙들어(`widthIn(min)` + `onSizeChanged` 단조 증가) 진행바 폭을 고정했다.
- 붙든 폭이 무한정 커지지 않도록 `HomeHeroRemainLabelMaxWidth`(120dp) 상한을 뒀다. 상한이 없으면 큰 글꼴 설정에서 라벨이 줄을 다 차지하고 진행바가 0 폭으로 사라진다.
- 자리를 예약하면 짧아진 표기가 그 안에서 왼쪽으로 쏠리므로 `textAlign = TextAlign.End` 로 카드 오른쪽 가장자리에 맞췄고, 상한에 걸려 잘릴 때를 위해 `overflow = Ellipsis` 를 함께 붙였다.

## 테스트

- `HomeScreenTest.continueListeningHero_progressBarKeepsWidthWhenRemainLabelShrinks` 추가. 남은 시간이 301초 → 300초로 바뀌어 표기가 `"5min 1sec Left"` → `"5min Left"` 로 좁아질 때 진행바 폭이 그대로인지 확인한다.
- 회귀를 실제로 잡는지 확인했다. 프로덕션 수정만 되돌리면 `expected:<166.0.dp> but was:<171.0.dp>` 로 실패하고, 복원하면 통과한다.
- `./gradlew :feature:home:testDebugUnitTest :feature:home:lintDebug` 통과 (34개).

## 남은 것

- 큰 글꼴(fontScale 2.0)에서 라벨이 상한에 걸려 잘리는 모습은 실기기 확인을 권한다. Robolectric 은 합성 폰트 메트릭을 써서 fontScale 을 올려도 폭이 변하지 않아 이 환경에서는 재현되지 않는다.
- 되감기처럼 표기가 되레 길어지는 경로에서는 폭이 한 번 넓어진 뒤 유지된다. 매초 출렁이는 것보다 낫다는 판단이며 상한이 그 범위를 막아 두지만, 의도된 트레이드오프라 코드 주석에 적어 뒀다.
- `core/ui` 의 `PlayedEpisodeItem` 에도 같은 구조(가중치 진행바 + 무가중치 `"9%"` → `"10%"` 라벨)가 남아 있다. 이번 범위 밖이라 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wxzKBAgA5cyEjiEaA5dt8