### PR TITLE
feat: 홈에서 검색 탭으로 바로 가는 검색 아이콘

### DIFF
--- a/app/src/main/kotlin/io/jacob/episodive/navigation/EpisodiveNavHost.kt
+++ b/app/src/main/kotlin/io/jacob/episodive/navigation/EpisodiveNavHost.kt
@@ -21,6 +21,11 @@ fun EpisodiveNavHost(
     navigator: EpisodiveNavigator,
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
     modifier: Modifier = Modifier,
+    onSearchShortcutClick: () -> Unit = {},
+    // 값이 아니라 읽는 함수를 받는다. navigation3 가 NavEntry 를 재사용하는 탓에 아래
+    // entryProvider 블록은 처음 캡처한 값에 갇힌다 — 자세한 이유는 searchEntries 문서 참고.
+    searchAutoFocus: () -> Boolean = { false },
+    onSearchAutoFocusHandled: () -> Unit = {},
 ) {
     val entryProvider = entryProvider<NavKey> {
         homeEntries(
@@ -28,11 +33,15 @@ fun EpisodiveNavHost(
             onChannelClick = { navigator.navigate(ChannelRoute(it)) },
             onMoreClick = { navigator.navigate(HomeMoreRoute(it)) },
             onBackClick = { navigator.goBack() },
+            // 탭 전환에 포커스 신호까지 얹어야 해서 navigator 를 직접 부르지 않는다.
+            onSearchClick = onSearchShortcutClick,
             onShowSnackbar = onShowSnackbar,
         )
         searchEntries(
             onPodcastClick = { navigator.navigate(PodcastRoute(it)) },
             onShowSnackbar = onShowSnackbar,
+            autoFocus = searchAutoFocus,
+            onAutoFocusHandled = onSearchAutoFocusHandled,
         )
         libraryEntries(
             onPodcastClick = { navigator.navigate(PodcastRoute(it)) },

--- a/app/src/main/kotlin/io/jacob/episodive/ui/EpisodiveApp.kt
+++ b/app/src/main/kotlin/io/jacob/episodive/ui/EpisodiveApp.kt
@@ -114,6 +114,10 @@ fun EpisodiveApp(
         return
     }
 
+    LaunchedEffect(appState.navigationState.topLevelRoute) {
+        appState.discardSearchAutoFocusIfTabLeft()
+    }
+
     // 위젯 딥링크 → 플레이어 시트 펼침/접힘 신호. 콜드(fresh onCreate) 타이밍에 일회성 effect 가
     // PlayerBar 구독 전 emit 되어 유실되지 않도록, 상태(시그널) 로 PlayerBar 에 전달한다.
     var expandPlayerSignal by remember { mutableIntStateOf(0) }
@@ -229,6 +233,14 @@ fun EpisodiveApp(
                     navigationState = appState.navigationState,
                     navigator = appState.navigator,
                     onShowSnackbar = onShowSnackbar,
+                    onSearchShortcutClick = {
+                        // 열려 있던 플레이어 시트가 검색창을 가리지 않도록 접는다 —
+                        // 팟캐스트로 넘어갈 때(L127)와 같은 이유다.
+                        collapsePlayerSignal++
+                        appState.navigateToSearchWithFocus()
+                    },
+                    searchAutoFocus = { appState.searchAutoFocus },
+                    onSearchAutoFocusHandled = appState::consumeSearchAutoFocus,
                 )
 
                 PlayerBar(

--- a/app/src/main/kotlin/io/jacob/episodive/ui/EpisodiveAppState.kt
+++ b/app/src/main/kotlin/io/jacob/episodive/ui/EpisodiveAppState.kt
@@ -1,12 +1,16 @@
 package io.jacob.episodive.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import io.jacob.episodive.MainActivityViewModel
 import io.jacob.episodive.core.data.util.NetworkMonitor
 import io.jacob.episodive.feature.home.navigation.HomeRoute
 import io.jacob.episodive.feature.podcast.navigation.PodcastRoute
+import io.jacob.episodive.feature.search.navigation.SearchRoute
 import io.jacob.episodive.navigation.BottomBarDestination
 import io.jacob.episodive.navigation.EpisodiveNavigationState
 import io.jacob.episodive.navigation.EpisodiveNavigator
@@ -48,6 +52,21 @@ class EpisodiveAppState(
 ) {
     val bottomBarDestinations: List<BottomBarDestination> = BottomBarDestination.entries
 
+    /**
+     * 검색 화면이 열리자마자 입력창에 포커스를 줘야 하는지. 홈의 검색 바로가기로 들어올
+     * 때만 켜지고, 검색 화면이 처리한 뒤 [consumeSearchAutoFocus] 로 곧바로 꺼진다.
+     *
+     * 상태로 두는 이유는 홈에서 검색 탭까지가 한 프레임에 끝나지 않기 때문이다. 일회성
+     * 이벤트로 쏘면 아직 구독하지 않은 검색 화면을 지나쳐 사라진다. 검색이 로딩 중이면
+     * 이 값이 그대로 남아 있다가 입력창이 실제로 그려질 때 쓰인다.
+     *
+     * 저장 상태로 만들지 않은 것은 의도한 선택이다. 화면 회전으로 이 값이 날아가면 포커스가
+     * 한 번 불발되는 데 그치지만, 살려 두면 회전 뒤에 사용자가 부르지 않은 키보드가 뒤늦게
+     * 올라온다. 불발이 오작동보다 낫다.
+     */
+    var searchAutoFocus by mutableStateOf(false)
+        private set
+
     fun navigateToBottomBarDestination(destination: BottomBarDestination) {
         val route = destination.navKey
         if (route == navigationState.topLevelRoute) {
@@ -59,6 +78,30 @@ class EpisodiveAppState(
 
     fun navigateToPodcast(podcastId: Long) {
         navigator.navigate(PodcastRoute(podcastId))
+    }
+
+    /** 홈의 검색 바로가기. 검색 탭으로 옮기면서 "바로 입력할 참이다"는 신호를 같이 켠다. */
+    fun navigateToSearchWithFocus() {
+        navigator.navigate(SearchRoute)
+        // 탭 전환만으로는 그 탭에 쌓여 있던 화면이 그대로 되살아난다. 검색하다 팟캐스트
+        // 상세로 파고든 채 떠났다면 검색창 대신 그 상세가 뜨므로, 루트까지 되감는다.
+        navigator.navigateToTabRoot()
+        searchAutoFocus = true
+    }
+
+    fun consumeSearchAutoFocus() {
+        searchAutoFocus = false
+    }
+
+    /**
+     * 검색 탭을 벗어났다면 대기 중이던 포커스 신호를 버린다.
+     *
+     * 신호는 검색바가 실제로 그려질 때만 소비되는데, 검색이 로딩·에러라 검색바가 아직 없는
+     * 사이에 다른 탭으로 가버리면 켜진 채로 남는다. 그대로 두면 한참 뒤 하단 바로 검색에
+     * 들어올 때 부르지 않은 키보드가 올라온다.
+     */
+    fun discardSearchAutoFocusIfTabLeft() {
+        if (navigationState.topLevelRoute != SearchRoute) consumeSearchAutoFocus()
     }
 
     val isOffline = networkMonitor.isOnline

--- a/app/src/test/kotlin/io/jacob/episodive/ui/EpisodiveAppStateTest.kt
+++ b/app/src/test/kotlin/io/jacob/episodive/ui/EpisodiveAppStateTest.kt
@@ -1,0 +1,147 @@
+package io.jacob.episodive.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import io.jacob.episodive.MainActivityViewModel
+import io.jacob.episodive.core.data.util.NetworkMonitor
+import io.jacob.episodive.feature.home.navigation.HomeRoute
+import io.jacob.episodive.feature.search.navigation.SearchRoute
+import io.jacob.episodive.navigation.BottomBarDestination
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * 홈의 검색 바로가기가 만드는 신호의 수명을 지키는 계약 테스트.
+ *
+ * 화면 단위 테스트(`HomeScreenTest`·`SearchScreenTest`)는 "아이콘을 누르면 콜백이 온다",
+ * "신호가 켜져 있으면 포커스가 잡힌다" 까지만 본다. 그 사이를 잇는 네비게이션과 신호 수명은
+ * 여기서만 드러난다.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EpisodiveAppStateTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val networkMonitor = object : NetworkMonitor {
+        override val isOnline: Flow<Boolean> = flowOf(true)
+    }
+
+    private val viewModel = mockk<MainActivityViewModel>(relaxed = true)
+
+    private lateinit var appState: EpisodiveAppState
+
+    private fun setUpAppState() {
+        composeTestRule.setContent {
+            appState = rememberEpisodiveAppState(
+                networkMonitor = networkMonitor,
+                viewModel = viewModel,
+            )
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun searchShortcut_movesToSearchTab() {
+        setUpAppState()
+
+        composeTestRule.runOnIdle { appState.navigateToSearchWithFocus() }
+
+        composeTestRule.runOnIdle {
+            assertEquals(SearchRoute, appState.navigationState.topLevelRoute)
+        }
+    }
+
+    @Test
+    fun searchShortcut_raisesFocusSignal() {
+        setUpAppState()
+
+        composeTestRule.runOnIdle { appState.navigateToSearchWithFocus() }
+
+        composeTestRule.runOnIdle { assertTrue(appState.searchAutoFocus) }
+    }
+
+    @Test
+    fun searchShortcut_rewindsSearchTabToItsRoot() {
+        // 검색하다 팟캐스트 상세로 파고든 채 탭을 떠나면 그 화면이 검색 탭 스택에 남는다.
+        // 탭 전환만 하면 검색창 대신 그 상세가 되살아나므로, 위에 쌓인 것을 걷어내야 한다.
+        setUpAppState()
+
+        composeTestRule.runOnIdle {
+            appState.navigateToBottomBarDestination(BottomBarDestination.SEARCH)
+            appState.navigateToPodcast(podcastId = 42L)
+        }
+        composeTestRule.runOnIdle {
+            appState.navigateToBottomBarDestination(BottomBarDestination.HOME)
+        }
+
+        composeTestRule.runOnIdle { appState.navigateToSearchWithFocus() }
+
+        composeTestRule.runOnIdle {
+            assertEquals(SearchRoute, appState.navigationState.topLevelRoute)
+            assertEquals(1, appState.navigationState.backStacks[SearchRoute]?.size)
+        }
+    }
+
+    @Test
+    fun bottomBarSearch_doesNotRaiseFocusSignal() {
+        // 하단 바로 들어가는 것은 둘러보러 가는 길이다. 키보드가 따라 올라오면 안 된다.
+        setUpAppState()
+
+        composeTestRule.runOnIdle {
+            appState.navigateToBottomBarDestination(BottomBarDestination.SEARCH)
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(SearchRoute, appState.navigationState.topLevelRoute)
+            assertFalse(appState.searchAutoFocus)
+        }
+    }
+
+    @Test
+    fun consumeSearchAutoFocus_clearsSignal() {
+        setUpAppState()
+
+        composeTestRule.runOnIdle { appState.navigateToSearchWithFocus() }
+        composeTestRule.runOnIdle { appState.consumeSearchAutoFocus() }
+
+        composeTestRule.runOnIdle { assertFalse(appState.searchAutoFocus) }
+    }
+
+    @Test
+    fun leavingSearchTabBeforeConsuming_discardsSignal() {
+        // 검색이 로딩이라 검색바가 아직 없는 사이에 다른 탭으로 가버린 상황. 신호가 남으면
+        // 나중에 하단 바로 검색에 들어올 때 부르지 않은 키보드가 올라온다.
+        setUpAppState()
+
+        composeTestRule.runOnIdle { appState.navigateToSearchWithFocus() }
+        composeTestRule.runOnIdle {
+            appState.navigateToBottomBarDestination(BottomBarDestination.HOME)
+            appState.discardSearchAutoFocusIfTabLeft()
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(HomeRoute, appState.navigationState.topLevelRoute)
+            assertFalse(appState.searchAutoFocus)
+        }
+    }
+
+    @Test
+    fun stayingOnSearchTab_keepsSignalUntilConsumed() {
+        // 같은 탭에 머무는 동안에는 신호가 살아 있어야 한다. 검색이 로딩을 끝내고 입력창을
+        // 그리는 순간에 쓰일 값이다.
+        setUpAppState()
+
+        composeTestRule.runOnIdle { appState.navigateToSearchWithFocus() }
+        composeTestRule.runOnIdle { appState.discardSearchAutoFocusIfTabLeft() }
+
+        composeTestRule.runOnIdle { assertTrue(appState.searchAutoFocus) }
+    }
+}

--- a/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/component/SearchBar.kt
+++ b/core/designsystem/src/main/kotlin/io/jacob/episodive/core/designsystem/component/SearchBar.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -75,6 +76,15 @@ fun EpisodiveSearchBar(
     contentOnExpand: @Composable (LazyListState) -> Unit = {},
     // 검색어가 비어 있을 때의 우측 슬롯. 동작이 붙어 있지 않은 아이콘을 놓지 않는다.
     trailingIconOnCollapse: @Composable () -> Unit = {},
+    /**
+     * 다른 화면에서 "검색하러 왔다"는 신호로 켜서 넘긴다. true 로 들어오면 펼치고 입력창에
+     * 포커스를 준 뒤 [onAutoFocusHandled] 로 신호를 돌려준다.
+     *
+     * 돌려주는 것이 핵심이다. 신호를 켠 채로 두면 검색 탭을 떠났다 하단 바로 다시 들어올 때
+     * 이 화면이 새로 컴포즈되면서 키보드가 또 올라온다 — 사용자가 부르지 않은 키보드다.
+     */
+    autoFocus: Boolean = false,
+    onAutoFocusHandled: () -> Unit = {},
 ) {
     var expanded by rememberSaveable { mutableStateOf(isExpanded) }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -112,6 +122,28 @@ fun EpisodiveSearchBar(
         }
     }
 
+    LaunchedEffect(autoFocus) {
+        if (!autoFocus) return@LaunchedEffect
+
+        try {
+            // 펼침을 먼저 켜 둔다. 포커스만 주면 M3 가 onFocusChanged 로 뒤늦게 펼치면서
+            // 결과 영역이 한 프레임 늦게 열린다. 접을 수 없는 검색바는 펼쳐 두면 되돌릴
+            // 길이 없으므로 포커스만 준다 — 나머지 접기 경로도 같은 가드를 쓴다.
+            if (isExpandable) expanded = true
+            // 펼침이 실제 노드에 반영된 뒤에 요청한다. 같은 프레임에 부르면 M3 가 입력
+            // 필드를 펼침 레이아웃으로 옮겨 그리는 중일 수 있다.
+            withFrameNanos { }
+            focusRequester.requestFocus()
+            // 포커스가 잡히면 IME 는 보통 알아서 올라오지만, 화면 전환 직후에는 그 자동
+            // 호출이 무시되는 기기가 있다. 명시적으로 한 번 더 부른다.
+            keyboardController?.show()
+        } finally {
+            // 중간에 실패하더라도 신호는 반드시 돌려준다. 켜진 채로 남으면 이 화면에
+            // 들어올 때마다 같은 시도가 되풀이된다.
+            onAutoFocusHandled()
+        }
+    }
+
     Column(
         modifier = modifier,
     ) {
@@ -125,8 +157,7 @@ fun EpisodiveSearchBar(
                     end = horizontalPadding,
                     top = topPadding,
                     bottom = bottomPadding,
-                )
-                .focusRequester(focusRequester),
+                ),
             windowInsets = WindowInsets(0, 0, 0, 0),
             shape = EpisodiveShapes.searchBar,
             // 바깥 컨테이너는 화면 배경과 같은 색으로 둬 눈에 띄지 않게 하고, 보이는
@@ -140,8 +171,12 @@ fun EpisodiveSearchBar(
             ),
             inputField = {
                 SearchBarDefaults.InputField(
+                    // 포커스 요청은 바깥 컨테이너가 아니라 입력 필드가 받아야 한다. 컨테이너에
+                    // 걸면 펼침 상태의 결과 목록까지 포함한 그룹으로 요청이 들어가, 어느 자식이
+                    // 포커스를 가져갈지가 트리 모양에 따라 달라진다.
                     modifier = Modifier
                         .fillMaxWidth()
+                        .focusRequester(focusRequester)
                         .height(LocalDimensionTheme.current.fieldHeight)
                         .clip(EpisodiveShapes.searchBar)
                         .background(MaterialTheme.colorScheme.surfaceContainerHigh)

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/HomeScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetValue
@@ -55,17 +56,20 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.jacob.episodive.core.designsystem.component.EpisodiveDragHandle
+import io.jacob.episodive.core.designsystem.component.EpisodiveIconButton
 import io.jacob.episodive.core.designsystem.component.SkeletonBox
 import io.jacob.episodive.core.designsystem.component.SkeletonContainer
 import io.jacob.episodive.core.designsystem.component.SkeletonCover
 import io.jacob.episodive.core.designsystem.component.SkeletonLine
 import io.jacob.episodive.core.designsystem.component.StateImage
+import io.jacob.episodive.core.designsystem.icon.EpisodiveIcons
 import io.jacob.episodive.core.designsystem.screen.ErrorScreen
 import io.jacob.episodive.core.designsystem.theme.EpisodiveHeroGradientEnd
 import io.jacob.episodive.core.designsystem.theme.EpisodiveShapes
@@ -102,6 +106,7 @@ internal fun HomeRoute(
     onPodcastClick: (Long) -> Unit,
     onChannelClick: (Long) -> Unit,
     onMoreClick: (HomeSection) -> Unit,
+    onSearchClick: () -> Unit,
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -124,7 +129,7 @@ internal fun HomeRoute(
     }
 
     when (val s = state) {
-        is HomeState.Loading -> HomeSkeleton()
+        is HomeState.Loading -> HomeSkeleton(onSearchClick = onSearchClick)
 
         is HomeState.Success -> HomeScreen(
             modifier = modifier
@@ -145,6 +150,8 @@ internal fun HomeRoute(
             onPodcastClick = { viewModel.sendAction(HomeAction.ClickPodcast(it)) },
             onChannelClick = { viewModel.sendAction(HomeAction.ClickChannel(it)) },
             onMoreClick = { viewModel.sendAction(HomeAction.ClickMore(it)) },
+            // 검색은 홈 데이터를 건드리지 않는 탭 전환이라 ViewModel 을 거치지 않는다.
+            onSearchClick = onSearchClick,
         )
 
         is HomeState.Error -> ErrorScreen(
@@ -178,6 +185,7 @@ internal fun HomeScreen(
     onChannelClick: (Long) -> Unit,
     // 섹션별로 콜백을 여덟 개 두지 않고 하나로 받는다 — 어느 섹션인지는 인자가 말해준다.
     onMoreClick: (HomeSection) -> Unit,
+    onSearchClick: () -> Unit = {},
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val screenHeight = this.maxHeight
@@ -210,6 +218,7 @@ internal fun HomeScreen(
                 ) {
                     HomeHeader(
                         title = stringResource(R.string.feature_home_title),
+                        onSearchClick = onSearchClick,
                     )
                 }
             },
@@ -411,14 +420,22 @@ private val HomeHeroCoverSize = HomeHeroCoverSizeDp.dp
  */
 private val HomeHeroRemainLabelMaxWidth = 120.dp
 
+/**
+ * 아이콘 버튼은 48dp 터치 영역 안에 24dp 아이콘을 가운데 두므로 좌우로 12dp 씩 빈 자리를
+ * 이미 갖고 있다. 헤더의 우측 여백에서 그만큼 덜어야 아이콘이 눈에 보이는 위치가 제목의
+ * 좌측 여백과 맞는다 — 덜지 않으면 아이콘만 홀로 안쪽으로 들어가 보인다.
+ */
+private val HomeHeaderActionInset = 12.dp
+
 @Composable
 private fun HomeHeader(
     modifier: Modifier = Modifier,
     title: String,
+    onSearchClick: () -> Unit = {},
 ) {
     val dimension = LocalDimensionTheme.current
 
-    Column(
+    Row(
         modifier = modifier
             .fillMaxWidth()
             // 홈은 BottomSheetScaffold의 topBar 슬롯을 쓰지 않아 인셋이 자동으로 오지 않는다.
@@ -426,16 +443,28 @@ private fun HomeHeader(
             .windowInsetsPadding(WindowInsets.statusBars)
             .padding(
                 start = dimension.headerPadding,
-                end = dimension.headerPadding,
+                // 여백이 아이콘 자체 여백보다 좁은 테마가 생기면 음수가 되어 크래시한다.
+                end = (dimension.headerPadding - HomeHeaderActionInset).coerceAtLeast(0.dp),
                 top = 16.dp,
                 bottom = 8.dp,
             ),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
+            // 제목이 길어져도 검색 버튼을 밀어내지 않도록 남는 폭만 차지하게 둔다.
+            modifier = Modifier.weight(1f),
             text = title,
             style = MaterialTheme.typography.headlineLarge,
             color = MaterialTheme.colorScheme.onSurface,
         )
+
+        EpisodiveIconButton(onClick = onSearchClick) {
+            Icon(
+                imageVector = EpisodiveIcons.Search,
+                contentDescription = stringResource(R.string.feature_home_search),
+                tint = MaterialTheme.colorScheme.onSurface,
+            )
+        }
     }
 }
 
@@ -624,7 +653,10 @@ private val HomeHeroSkeletonInitialHeight = 130.dp
  * 화면은 보통 3~5개 섹션만 뜨는데 8개를 그리면 스크롤 길이가 절반으로 줄며 스크롤바가 튄다.
  */
 @Composable
-private fun HomeSkeleton(modifier: Modifier = Modifier) {
+private fun HomeSkeleton(
+    modifier: Modifier = Modifier,
+    onSearchClick: () -> Unit = {},
+) {
     val dimension = LocalDimensionTheme.current
     val density = LocalDensity.current
 
@@ -634,7 +666,11 @@ private fun HomeSkeleton(modifier: Modifier = Modifier) {
     var heroAreaHeight by remember { mutableStateOf(HomeHeroSkeletonInitialHeight) }
 
     Column(modifier = modifier.fillMaxSize()) {
-        HomeHeader(title = stringResource(R.string.feature_home_title))
+        // 검색은 홈 데이터가 아직 없어도 갈 수 있는 곳이라, 로딩 중에도 눌리게 둔다.
+        HomeHeader(
+            title = stringResource(R.string.feature_home_title),
+            onSearchClick = onSearchClick,
+        )
 
         Box(modifier = Modifier.fillMaxSize()) {
             // 시트 배경은 SkeletonContainer 바깥의 별도 노드에서 먼저 칠한다. 안에서 칠하면

--- a/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/io/jacob/episodive/feature/home/navigation/HomeNavigation.kt
@@ -20,6 +20,7 @@ fun EntryProviderScope<NavKey>.homeEntries(
     onChannelClick: (Long) -> Unit,
     onMoreClick: (HomeSection) -> Unit,
     onBackClick: () -> Unit,
+    onSearchClick: () -> Unit,
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
 ) {
     entry<HomeRoute> {
@@ -27,6 +28,7 @@ fun EntryProviderScope<NavKey>.homeEntries(
             onPodcastClick = onPodcastClick,
             onChannelClick = onChannelClick,
             onMoreClick = onMoreClick,
+            onSearchClick = onSearchClick,
             onShowSnackbar = onShowSnackbar,
         )
     }

--- a/feature/home/src/main/res/values-ko/strings.xml
+++ b/feature/home/src/main/res/values-ko/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_home_title">홈</string>
+    <string name="feature_home_search">검색</string>
     <string name="feature_home_section_my_recent_feeds">나의 최신 피드</string>
     <string name="feature_home_section_random_episodes">랜덤 에피소드</string>
     <string name="feature_home_section_my_trending_feeds">나의 인기 피드</string>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_home_title">Home</string>
+    <string name="feature_home_search">Search</string>
     <string name="feature_home_section_my_recent_feeds">My recent published</string>
     <string name="feature_home_section_random_episodes">Random episodes</string>
     <string name="feature_home_section_my_trending_feeds">My trending feeds</string>

--- a/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeScreenTest.kt
+++ b/feature/home/src/test/kotlin/io/jacob/episodive/feature/home/HomeScreenTest.kt
@@ -23,6 +23,7 @@ import io.jacob.episodive.core.testing.model.liveEpisodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestDataList
 import io.jacob.episodive.feature.home.navigation.HomeSection
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,6 +53,7 @@ class HomeScreenTest {
         onPodcastClick: (Long) -> Unit = {},
         onChannelClick: (Long) -> Unit = {},
         onMoreClick: (HomeSection) -> Unit = {},
+        onSearchClick: () -> Unit = {},
         // 이어듣기 목록을 화면이 뜬 뒤에 바꿔야 하는 테스트를 위한 통로. 주면 [playingEpisodes]
         // 대신 이 상태를 읽어, 값을 바꾸는 것만으로 카드가 다시 그려진다.
         playingEpisodesState: State<List<Episode>>? = null,
@@ -75,6 +77,7 @@ class HomeScreenTest {
                     onPodcastClick = onPodcastClick,
                     onChannelClick = onChannelClick,
                     onMoreClick = onMoreClick,
+                    onSearchClick = onSearchClick,
                 )
             }
         }
@@ -463,6 +466,44 @@ class HomeScreenTest {
         setHomeScreen()
 
         composeTestRule.onNodeWithText("Home").assertIsDisplayed()
+    }
+
+    // --- Search shortcut ---
+
+    @Test
+    fun header_showsSearchAction() {
+        setHomeScreen()
+
+        composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
+    }
+
+    @Test
+    fun searchAction_clicked_invokesCallback() {
+        var searchClicked = false
+        setHomeScreen(onSearchClick = { searchClicked = true })
+
+        composeTestRule.onNodeWithContentDescription("Search").performClick()
+
+        assertTrue(searchClicked)
+    }
+
+    @Test
+    fun searchAction_isShownEvenWhenEveryFeedIsEmpty() {
+        // 검색은 홈 데이터와 무관한 출구다. 피드가 통째로 비어 볼 것이 없을 때야말로
+        // 가장 필요한 버튼이라, 섹션이 하나도 안 그려지는 상황에서도 남아 있어야 한다.
+        setHomeScreen(
+            playingEpisodes = emptyList(),
+            userRecentPodcasts = emptyList(),
+            randomEpisodes = emptyList(),
+            userTrendingPodcasts = emptyList(),
+            followedPodcasts = emptyList(),
+            localTrendingPodcasts = emptyList(),
+            foreignTrendingPodcasts = emptyList(),
+            liveEpisodes = emptyList(),
+            channels = emptyList(),
+        )
+
+        composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
     }
 
     // --- New: Empty local/foreign trending sections still show other content ---

--- a/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/SearchScreen.kt
@@ -76,6 +76,15 @@ fun SearchRoute(
     viewModel: SearchViewModel = hiltViewModel(),
     onPodcastClick: (Long) -> Unit,
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
+    /**
+     * 홈의 검색 바로가기로 들어왔다는 표시. 켜져 있으면 입력창을 펼치고 키보드까지 올린다.
+     *
+     * 로딩 중에는 검색바 자체가 없어 신호가 그대로 남아 있다가, [SearchState.Success] 로
+     * 바뀌어 입력창이 그려지는 순간 소비된다. 하단 바로 들어온 진입은 이 값이 false 라
+     * 예전처럼 조용히 열린다.
+     */
+    autoFocus: Boolean = false,
+    onAutoFocusHandled: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -107,6 +116,8 @@ fun SearchRoute(
                 onRecentSearchClick = { viewModel.sendAction(SearchAction.ClickRecentSearch(it)) },
                 onRemoveRecentSearch = { viewModel.sendAction(SearchAction.RemoveRecentSearch(it)) },
                 onClearRecentSearches = { viewModel.sendAction(SearchAction.ClearRecentSearches) },
+                autoFocus = autoFocus,
+                onAutoFocusHandled = onAutoFocusHandled,
             )
         }
 
@@ -181,6 +192,8 @@ internal fun SearchScreen(
     onRemoveRecentSearch: (RecentSearch) -> Unit = {},
     onClearRecentSearches: () -> Unit = {},
     isExpanded: Boolean = false,
+    autoFocus: Boolean = false,
+    onAutoFocusHandled: () -> Unit = {},
 ) {
     EpisodiveScaffold(
         modifier = modifier,
@@ -223,7 +236,9 @@ internal fun SearchScreen(
                     onRemoveRecentSearch = onRemoveRecentSearch,
                     onClearRecentSearches = onClearRecentSearches
                 )
-            }
+            },
+            autoFocus = autoFocus,
+            onAutoFocusHandled = onAutoFocusHandled,
         )
     }
 }

--- a/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/navigation/SearchNavigation.kt
+++ b/feature/search/src/main/kotlin/io/jacob/episodive/feature/search/navigation/SearchNavigation.kt
@@ -8,14 +8,28 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object SearchRoute : NavKey
 
+/**
+ * [autoFocus] 는 라우트 인자가 아니라 앱이 들고 있는 신호다. [SearchRoute] 는 탭 루트라
+ * 백스택 키로도 쓰이므로, 값을 실어 나르는 순간 같은 탭이 서로 다른 키가 되어 스택 매칭이
+ * 깨진다. 그래서 키는 그대로 두고 신호만 따로 내려보낸다.
+ *
+ * **`Boolean` 이 아니라 읽는 함수인 것이 핵심이다.** navigation3 는 백스택이 그대로면
+ * `NavEntry` 를 재사용하므로, 아래 `entry { }` 블록은 **처음 만들어질 때 캡처한 값**을 계속
+ * 쓴다. 값을 그대로 받으면 나중에 신호가 켜져도 이 화면은 영영 `false` 만 본다 — 실제로
+ * 겪은 버그다. 함수로 받아 컴포지션 안에서 읽으면 최신 값이 오고 스냅샷 구독도 걸린다.
+ */
 fun EntryProviderScope<NavKey>.searchEntries(
     onPodcastClick: (Long) -> Unit,
     onShowSnackbar: suspend (message: String, actionLabel: String?) -> Boolean,
+    autoFocus: () -> Boolean = { false },
+    onAutoFocusHandled: () -> Unit = {},
 ) {
     entry<SearchRoute> {
         SearchRoute(
             onPodcastClick = onPodcastClick,
             onShowSnackbar = onShowSnackbar,
+            autoFocus = autoFocus(),
+            onAutoFocusHandled = onAutoFocusHandled,
         )
     }
 }

--- a/feature/search/src/test/kotlin/io/jacob/episodive/feature/search/SearchScreenTest.kt
+++ b/feature/search/src/test/kotlin/io/jacob/episodive/feature/search/SearchScreenTest.kt
@@ -2,6 +2,7 @@ package io.jacob.episodive.feature.search
 
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -16,6 +17,8 @@ import io.jacob.episodive.core.model.RecentSearch
 import io.jacob.episodive.core.model.SearchResult
 import io.jacob.episodive.core.testing.model.episodeTestDataList
 import io.jacob.episodive.core.testing.model.podcastTestDataList
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,6 +45,8 @@ class SearchScreenTest {
         onRemoveRecentSearch: (RecentSearch) -> Unit = {},
         onClearRecentSearches: () -> Unit = {},
         isExpanded: Boolean = false,
+        autoFocus: Boolean = false,
+        onAutoFocusHandled: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             EpisodiveTheme {
@@ -60,6 +65,8 @@ class SearchScreenTest {
                     onRemoveRecentSearch = onRemoveRecentSearch,
                     onClearRecentSearches = onClearRecentSearches,
                     isExpanded = isExpanded,
+                    autoFocus = autoFocus,
+                    onAutoFocusHandled = onAutoFocusHandled,
                 )
             }
         }
@@ -463,5 +470,47 @@ class SearchScreenTest {
         composeTestRule
             .onAllNodesWithContentDescription("See all", substring = true)
             .assertCountEquals(0)
+    }
+
+    // --- Auto focus (홈의 검색 바로가기로 들어온 경우) ---
+
+    @Test
+    fun autoFocus_expandsSearchBar() {
+        // 펼침 여부는 접힘 전용 콘텐츠로 판정한다 — 펼쳐지면 트렌딩 섹션 자리에 검색
+        // 결과 영역이 들어서므로 그 제목이 사라진다.
+        setSearchScreen(autoFocus = true)
+
+        composeTestRule.onNodeWithText("Global trending feeds").assertDoesNotExist()
+    }
+
+    @Test
+    fun autoFocus_focusesInputField() {
+        setSearchScreen(autoFocus = true)
+
+        composeTestRule
+            .onNodeWithText("What do you want to listen to?")
+            .assertIsFocused()
+    }
+
+    @Test
+    fun autoFocus_signalIsConsumed() {
+        // 소비하지 않으면 검색 탭을 떠났다 하단 바로 다시 들어올 때 키보드가 또 올라온다.
+        var handled = false
+        setSearchScreen(autoFocus = true, onAutoFocusHandled = { handled = true })
+
+        // 포커스 요청은 한 프레임 뒤로 미뤄져 있다. 프레임을 진행시키지 않으면 아직 아무
+        // 일도 일어나지 않은 시점을 검사하게 된다.
+        composeTestRule.waitForIdle()
+
+        assertTrue(handled)
+    }
+
+    @Test
+    fun withoutAutoFocus_searchBarStaysCollapsed() {
+        var handled = false
+        setSearchScreen(autoFocus = false, onAutoFocusHandled = { handled = true })
+
+        composeTestRule.onNodeWithText("Global trending feeds").assertIsDisplayed()
+        assertFalse(handled)
     }
 }


### PR DESCRIPTION
## 변경 사항

- 홈 헤더 우측에 검색 아이콘을 추가했다. 누르면 검색 탭으로 옮겨 가면서 입력창을 펼치고 포커스와 키보드까지 함께 올린다.
- 포커스 요청은 라우트 인자가 아니라 앱이 들고 있는 신호(`EpisodiveAppState.searchAutoFocus`)로 내려보낸다. `SearchRoute` 는 탭 루트라 백스택 키로도 쓰여서, 값을 실어 나르면 같은 탭이 서로 다른 키가 되어 스택 매칭이 깨진다.
- 신호는 검색바가 처리한 뒤 곧바로 소비한다. 남겨 두면 나중에 하단 바로 검색에 들어올 때 부르지 않은 키보드가 올라온다.
- `EpisodiveSearchBar` 의 포커스 요청을 컨테이너에서 입력 필드로 옮겼다. 컨테이너에 걸면 펼침 상태의 결과 목록까지 포함한 그룹으로 요청이 들어가, 어느 자식이 포커스를 가져갈지가 트리 모양에 따라 달라진다.
- 로딩 중에도 검색 아이콘은 눌린다. 검색은 홈 데이터와 무관한 출구라, 피드가 비어 볼 것이 없을 때야말로 가장 필요한 버튼이다.

### 리뷰에서 걸러낸 것들

- **탭 전환만으로는 부족했다.** 검색하다 팟캐스트 상세로 파고든 채 떠났다면 검색창 대신 그 상세가 되살아난다. 루트까지 되감도록 고쳤다.
- **로딩 중 이탈 시 신호가 영구히 남았다.** 검색바가 아직 없는 사이에 다른 탭으로 가면 신호가 켜진 채로 방치돼, 한참 뒤 하단 바 진입에서 키보드가 튀어나온다. 검색 탭을 벗어나면 버리도록 했다.
- **navigation3 의 `NavEntry` 재사용에 걸려 자동 포커스가 통째로 불발됐다.** 백스택이 그대로면 엔트리가 재사용되므로 `entryProvider` 블록은 처음 캡처한 값에 갇힌다. 실기기 로그로 `entryProvider built autoFocus=true` 바로 뒤에 `SearchRoute compose autoFocus=false` 가 찍히는 것을 확인했고, 값 대신 **읽는 함수**를 넘겨 해결했다.
- 접을 수 없는 검색바(`isExpandable = false`)는 펼치지 않고 포커스만 준다. 펼쳐 두면 되돌릴 UI 가 없다.
- 헤더 우측 여백의 음수 가드, `values-ko` 번역 누락도 함께 처리했다.

## 테스트

`./gradlew testDebugUnitTest lintDebug` — 통과.

새 테스트 14개:

- `EpisodiveAppStateTest` (신규, 7개) — 바로가기가 검색 탭으로 옮기고 신호를 켜는지, 쌓인 스택을 루트까지 되감는지, 하단 바 진입은 신호를 켜지 않는지, 탭을 벗어나면 신호를 버리고 머물면 유지하는지.
- `SearchScreenTest` (4개) — 신호가 켜지면 펼쳐지고 입력창에 포커스가 잡히며 신호가 소비되는지, 꺼져 있으면 접힌 채 그대로인지.
- `HomeScreenTest` (3개) — 헤더에 검색 액션이 있는지, 눌리면 콜백이 오는지, 피드가 전부 비어도 남아 있는지.

에뮬레이터(Pixel, API 36) 실기기 확인:

| 시나리오 | 결과 |
|:--|:--|
| 홈 검색 아이콘 탭 | 검색 탭 이동 + 펼침 + 포커스 + 키보드 (`mInputShown=true`) |
| 하단 바로 검색 탭 진입 | 접힌 상태 유지, 키보드 없음 (`mInputShown=false`) |
| 검색 탭에 팟캐스트 상세를 쌓아 둔 뒤 홈에서 바로가기 | 상세가 아니라 검색창에 도착, 키보드 올라옴 |

## 알려진 한계

- 화면을 회전하면 대기 중이던 신호가 사라져 포커스가 한 번 불발된다(`EpisodiveAppState` 가 저장 상태가 아니다). 살려 두면 회전 뒤에 부르지 않은 키보드가 올라오므로, 불발이 오작동보다 낫다고 보고 그대로 뒀다.
- 전체 테스트를 병렬로 돌리면 `:core:database` 가 `NoClassDefFoundError: io.mockk.impl.JvmMockKGateway` 로 간헐 실패한다. 이 PR 과 무관하며, 변경을 stash 한 상태와 적용한 상태 양쪽에서 성공·실패가 번갈아 재현되는 기존 환경 문제다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKz95CayHQ76YqtP6HPaEv